### PR TITLE
Add AddQueuedCookiesToResponse to web middleware

### DIFF
--- a/src/Http/Kernel.php
+++ b/src/Http/Kernel.php
@@ -32,6 +32,7 @@ class Kernel extends \Illuminate\Foundation\Http\Kernel
     protected $middlewareGroups = [
         'web' => [
             \Illuminate\Cookie\Middleware\EncryptCookies::class,
+            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             Middleware\VerifyCsrfToken::class,


### PR DESCRIPTION
I ran in to some issues with the `TestResponse@assertCookie` method because cookies were never added to the response. Adding the `AddQueuedCookiesToResponse` middleware to the "web" middleware group fixes the issue.

Of course, you could easily add the middleware to your test suite, but I still think this PR is good for consistency (this is the [default behaviour in Laravel](https://github.com/laravel/laravel/blob/master/app/Http/Kernel.php#L31))

Code to reproduce:

``` php
// Set up a route that queues a cookie...
Route::middleware('web')->get('set-cookie', function () {
    app('cookie')->queue('foo', 'bar', 10);
    return 'ok';
});

// And then a test...
public function testCookieWasQueued()
{
    $this->get('set-cookie')->assertCookie('foo', 'bar');
}
```

Without this middleware, the assertion will fail.
