### PR TITLE
Added missing 5.5 refresh database trait.

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -115,6 +115,10 @@ abstract class TestCase extends BaseTestCase implements TestCaseContract
     {
         $uses = array_flip(class_uses_recursive(static::class));
 
+        if (isset($uses[RefreshDatabase::class])) {
+            $this->refreshDatabase();
+        }
+
         if (isset($uses[DatabaseMigrations::class])) {
             $this->runDatabaseMigrations();
         }


### PR DESCRIPTION
In 5.5 there is a new [RefreshDatabase](https://github.com/laravel/framework/blob/bd352a0d2ca93775fce8ef02365b03fc4fb8cbb0/src/Illuminate/Foundation/Testing/RefreshDatabase.php) trait that is in the original [setupTraits](https://github.com/laravel/framework/blob/bd352a0d2ca93775fce8ef02365b03fc4fb8cbb0/src/Illuminate/Foundation/Testing/TestCase.php#L103-L105).