### PR TITLE
Clear Carbon mock in tearDown method

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -3,6 +3,7 @@
 namespace Orchestra\Testbench;
 
 use Mockery;
+use Illuminate\Support\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Console\Application as Artisan;
 use PHPUnit\Framework\TestCase as BaseTestCase;
@@ -163,6 +164,10 @@ abstract class TestCase extends BaseTestCase implements Contracts\TestCase
             }
 
             Mockery::close();
+        }
+        
+        if (class_exists(Carbon::class)) {
+            Carbon::setTestNow();   
         }
 
         $this->afterApplicationCreatedCallbacks = [];

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -166,9 +166,7 @@ abstract class TestCase extends BaseTestCase implements Contracts\TestCase
             Mockery::close();
         }
         
-        if (class_exists(Carbon::class)) {
-            Carbon::setTestNow();   
-        }
+        Carbon::setTestNow();
 
         $this->afterApplicationCreatedCallbacks = [];
         $this->beforeApplicationDestroyedCallbacks = [];


### PR DESCRIPTION
Just like calling `Mockery::close()`, we can call `Carbon::setTestNow()` to clear the mock.