### PR TITLE
Add resolveServiceProviderConfiguration

### DIFF
--- a/src/Concerns/CreatesApplication.php
+++ b/src/Concerns/CreatesApplication.php
@@ -234,6 +234,8 @@ trait CreatesApplication
             ! is_null($timezone) && date_default_timezone_set($timezone);
         });
 
+        $this->resolveServiceProviderConfiguration($app);
+
         $app['config']['app.aliases'] = $this->resolveApplicationAliases($app);
         $app['config']['app.providers'] = $this->resolveApplicationProviders($app);
     }
@@ -325,6 +327,17 @@ trait CreatesApplication
     }
 
     /**
+     * Resolve configuration before service providers are registered.
+     *
+     * @param  \Illuminate\Foundation\Application   $app
+     *
+     * @return void
+     */
+    protected function resolveServiceProviderConfiguration($app) {
+        // Empty implementation which can be overridden.
+    }
+
+    /**
      * Define environment setup.
      *
      * @param  \Illuminate\Foundation\Application   $app
@@ -332,4 +345,5 @@ trait CreatesApplication
      * @return void
      */
     abstract protected function getEnvironmentSetUp($app);
+
 }

--- a/tests/ServiceProviderConfigTest.php
+++ b/tests/ServiceProviderConfigTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Orchestra\Testbench\Tests;
+
+use Orchestra\Testbench\TestCase;
+use Orchestra\Testbench\Tests\Stubs\Providers\ConfigurableServiceProvider;
+
+class ServiceProviderConfigTest extends TestCase
+{
+    /** @test */
+    public function it_can_resolve_configuration_before_a_service_provider_is_run()
+    {
+        $this->assertEquals('test', ConfigurableServiceProvider::$configValue);
+    }
+
+    protected function resolveServiceProviderConfiguration($app)
+    {
+        $app['config']->set('test', 'test');
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [
+            ConfigurableServiceProvider::class,
+        ];
+    }
+}

--- a/tests/Stubs/Providers/ConfigurableServiceProvider.php
+++ b/tests/Stubs/Providers/ConfigurableServiceProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Orchestra\Testbench\Tests\Stubs\Providers;
+
+class ConfigurableServiceProvider extends ServiceProvider
+{
+    public static $configValue;
+
+    public function register()
+    {
+        self::$configValue = config('test');
+    }
+}


### PR DESCRIPTION
There's been several times where I wanted to set configuration in a test case, before a service provider was registered, so that the service provider can use that custom config.

As far as I can tell, there's no real hook to do this. You can achieve this by overriding `getPackageProviders` and setting config before returning an array of service providers, but it doesn't seem like the correct place.

I also looked at `setUp` and `getEnvironmentSetUp`, but these seem to run after the service providers are already registered.

Furthermore, there is `\Orchestra\Testbench\Concerns\CreatesApplication:: resolveApplicationConfiguration` which should be the place to put this, but you cannot override it, as this line has to run:

```php
$app->make('Illuminate\Foundation\Bootstrap\LoadConfiguration')->bootstrap($app);
```

before you're able to set config. 

So this PR adds a hook `resolveServiceProviderConfiguration` which is called after the configuration is initialised, but before the service providers are. 

Please let me know if maybe I missed something, or changes are required.