### PR TITLE
Directly use Carbon\Carbon.

### DIFF
--- a/src/Concerns/Testing.php
+++ b/src/Concerns/Testing.php
@@ -3,7 +3,7 @@
 namespace Orchestra\Testbench\Concerns;
 
 use Mockery;
-use Illuminate\Support\Carbon;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Console\Application as Artisan;


### PR DESCRIPTION
Since recent versions of `nesbot/carbon` now support serialisation and macros, there is no point at keeping using `\Illuminate\Support\Carbon`.

We can keep consistant with the rest of the codebase in `testbench-core`, and use `Carbon\Carbon`.