### PR TITLE
Update CreatesApplication.php

### DIFF
--- a/src/Concerns/CreatesApplication.php
+++ b/src/Concerns/CreatesApplication.php
@@ -300,12 +300,12 @@ trait CreatesApplication
      */
     protected function resolveApplicationBootstrappers($app)
     {
+        $this->getEnvironmentSetUp($app);
+        
         $app->make('Illuminate\Foundation\Bootstrap\HandleExceptions')->bootstrap($app);
         $app->make('Illuminate\Foundation\Bootstrap\RegisterFacades')->bootstrap($app);
         $app->make('Illuminate\Foundation\Bootstrap\SetRequestForConsole')->bootstrap($app);
         $app->make('Illuminate\Foundation\Bootstrap\RegisterProviders')->bootstrap($app);
-
-        $this->getEnvironmentSetUp($app);
 
         $app->make('Illuminate\Foundation\Bootstrap\BootProviders')->bootstrap($app);
 


### PR DESCRIPTION
`getEnvironmentSetUp()` is a method where users can override to configure and setup configs. That is:
```php
/**
 * Define environment setup.
 *
 * @param  \Illuminate\Foundation\Application  $app
 * @return void
 */
protected function getEnvironmentSetUp($app)
{
    // Setup default database to use sqlite :memory:
    $app['config']->set('database.default', 'testbench');
    $app['config']->set('database.connections.testbench', [
        'driver'   => 'sqlite',
        'database' => ':memory:',
        'prefix'   => '',
    ]);
}
```

However, within the source code, I noticed it's called AFTER the service providers are bootstrapped.
The problem with that is if the service providers uses the config itself (i.e. within the `register()` method), then errors and issues would arise.