### PR TITLE
[3.8] Add PHPUnit 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,14 +32,14 @@
     "require-dev": {
         "laravel/framework": "~5.8.0",
         "mockery/mockery": "^1.0",
-        "phpunit/phpunit": "^7.5"
+        "phpunit/phpunit": "^7.5|^8.0"
     },
     "suggest": {
         "laravel/framework": "Required for testing (~5.8.0).",
         "mockery/mockery": "Allow to use Mockery for testing (^1.0).",
         "orchestra/testbench-browser-kit": "Allow to use legacy Laravel BrowserKit for testing (^3.8).",
         "orchestra/testbench-dusk": "Allow to use Laravel Dusk for testing (^3.8).",
-        "phpunit/phpunit": "Allow to use PHPUnit for testing (^7.0)."
+        "phpunit/phpunit": "Allow to use PHPUnit for testing (^7.0|^8.0)."
     },
     "extra": {
         "branch-alias": {

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -36,7 +36,7 @@ abstract class TestCase extends PHPUnit implements Contracts\TestCase
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->setUpTheTestEnvironment();
     }
@@ -46,7 +46,7 @@ abstract class TestCase extends PHPUnit implements Contracts\TestCase
      *
      * @return void
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->tearDownTheTestEnvironment();
     }


### PR DESCRIPTION
This change allows installs for PHPUnit 8 and adds the necessary void return type to the setUp and tearDown methods. This will keep backwards compatibility with PHPUnit 7 and both versions can be used. This allows, amongst else, Laravel 5.8 to be released with support for both PHPUnit 7 & 8.

@crynobone can you merge this and release 3.8? Then we can go ahead and merge https://github.com/laravel/framework/pull/27441

Thanks! :)