### PR TITLE
Uncomment expire_on_close

### DIFF
--- a/laravel/config/session.php
+++ b/laravel/config/session.php
@@ -33,7 +33,7 @@ return [
 
     'lifetime' => env('SESSION_LIFETIME', 120),
 
-    // 'expire_on_close' => false,
+    'expire_on_close' => false,
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Laravel 5.8 require this config when get the cookie lifetime in seconds.

```php
       return $config['expire_on_close'] ? 0 : Date::instance(
            Carbon::now()->addRealMinutes($config['lifetime'])
        );
```
[Referer](https://github.com/laravel/framework/blob/66b56bd0b73a76f8f8c76238ca6b78d11f6938df/src/Illuminate/Session/Middleware/StartSession.php#L181)

In the tests i get this error:

```
testing.ERROR: Undefined index: expire_on_close {"exception":"[object] (ErrorException(code: 0): Undefined index: expire_on_close at /source/vendor/laravel/framework/src/Illuminate/Session/Middleware/StartSession.php:181)
```

