### PR TITLE
Replace 'Allow to use' with 'Allow using' in composer suggestions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,10 +37,10 @@
     },
     "suggest": {
         "laravel/framework": "Required for testing (^6.0).",
-        "mockery/mockery": "Allow to use Mockery for testing (^1.2.3).",
-        "orchestra/testbench-browser-kit": "Allow to use legacy Laravel BrowserKit for testing (^4.0).",
-        "orchestra/testbench-dusk": "Allow to use Laravel Dusk for testing (^4.0).",
-        "phpunit/phpunit": "Allow to use PHPUnit for testing (^8.3)."
+        "mockery/mockery": "Allow using Mockery for testing (^1.2.3).",
+        "orchestra/testbench-browser-kit": "Allow using legacy Laravel BrowserKit for testing (^4.0).",
+        "orchestra/testbench-dusk": "Allow using Laravel Dusk for testing (^4.0).",
+        "phpunit/phpunit": "Allow using PHPUnit for testing (^8.3)."
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
Tiny language tweak.

Caught my eye when installing Laravel locally