### PR TITLE
[master]Get method name without the DataSet.

### DIFF
--- a/src/Concerns/CreatesApplication.php
+++ b/src/Concerns/CreatesApplication.php
@@ -313,7 +313,7 @@ trait CreatesApplication
 
         if ($this instanceof TestCase) {
             $annotations = TestUtil::parseTestMethodAnnotations(
-                static::class, $this->getName()
+                static::class, $this->getName(false)
             );
 
             Collection::make($annotations)->each(function ($location) use ($app) {


### PR DESCRIPTION
This pr fixes the failing tests on our project, introduced by the recent refactor due to the depreciation of `PHPUnit::getAnnotations()`.