### PR TITLE
Allow using yml (vs yaml) for testbench file

### DIFF
--- a/testbench
+++ b/testbench
@@ -19,6 +19,8 @@ $config = [
 
 if (file_exists("{$workingPath}/testbench.yaml")) {
     $config = Symfony\Component\Yaml\Yaml::parseFile("{$workingPath}/testbench.yaml");
+} elseif (file_exists("{$workingPath}/testbench.yml")) {
+    $config = Symfony\Component\Yaml\Yaml::parseFile("{$workingPath}/testbench.yml");
 }
 
 $commander = new Orchestra\Testbench\Console\Commander($config, $workingPath);


### PR DESCRIPTION
In my current project all my yaml files use the `.yml`, except for `testbench` that uses `.yaml`.

With this change it will first look for `testbench.yaml` before looking for a `testbench.yml` file.