### PR TITLE
Change the requireApplicationCachedRoutes method to match new Laravel caching method

### DIFF
--- a/src/Concerns/HandlesRoutes.php
+++ b/src/Concerns/HandlesRoutes.php
@@ -93,7 +93,9 @@ trait HandlesRoutes
     protected function requireApplicationCachedRoutes(): void
     {
         $this->app->booted(function () {
-            require $this->app->getCachedRoutesPath();
+            $cachesRoutes = $this->app['files']->get($this->app->getCachedRoutesPath());
+
+            $this->app['router']->setRoutes(unserialize($cachesRoutes));
         });
     }
 }


### PR DESCRIPTION
This PR was created in the following of this PR in laravel/framework#37968.

It may fail to pass the tests because of circular dependency with laravel itself.
Please don't close this PR until the reference PR is merged/closed.

Also, it may need other commits also.
Thanks in advance.