### PR TITLE
Workaround for PHP 8.1 trait failure

### DIFF
--- a/src/Console/Commander.php
+++ b/src/Console/Commander.php
@@ -60,7 +60,11 @@ class Commander
      */
     public static function applicationBasePath()
     {
-        return CreatesApplication::applicationBasePath();
+        $app = new class {
+            use CreatesApplication;
+        };
+
+        return $app::applicationBasePath();
     }
 
     /**


### PR DESCRIPTION
This is a workaround for a PHP 8.1 failure where you cannot call static methods on trait directly anymore. See https://github.com/laravel/framework/runs/3742572903#step:8:129