### PR TITLE
Add possibility to avoid rollback after migration

### DIFF
--- a/src/Concerns/WithLaravelMigrations.php
+++ b/src/Concerns/WithLaravelMigrations.php
@@ -10,9 +10,10 @@ trait WithLaravelMigrations
      * Migrate Laravel's default migrations.
      *
      * @param  string|array<string, mixed>  $database
+     * @param  bool                         $rollback
      * @return void
      */
-    protected function loadLaravelMigrations($database = []): void
+    protected function loadLaravelMigrations($database = [], bool $rollback = true): void
     {
         $options = \is_array($database) ? $database : ['--database' => $database];
 
@@ -23,16 +24,19 @@ trait WithLaravelMigrations
 
         $this->resetApplicationArtisanCommands($this->app);
 
-        $this->beforeApplicationDestroyed(fn () => $migrator->rollback());
+        if ($rollback) {
+            $this->beforeApplicationDestroyed(fn () => $migrator->rollback());
+        }
     }
 
     /**
      * Migrate all Laravel's migrations.
      *
      * @param  string|array<string, mixed>  $database
+     * @param  bool                         $rollback
      * @return void
      */
-    protected function runLaravelMigrations($database = []): void
+    protected function runLaravelMigrations($database = [], bool $rollback = true): void
     {
         $options = \is_array($database) ? $database : ['--database' => $database];
 
@@ -41,6 +45,8 @@ trait WithLaravelMigrations
 
         $this->resetApplicationArtisanCommands($this->app);
 
-        $this->beforeApplicationDestroyed(fn () => $migrator->rollback());
+        if ($rollback) {
+            $this->beforeApplicationDestroyed(fn () => $migrator->rollback());
+        }
     }
 }

--- a/src/Concerns/WithLoadMigrationsFrom.php
+++ b/src/Concerns/WithLoadMigrationsFrom.php
@@ -11,11 +11,12 @@ trait WithLoadMigrationsFrom
      * Define hooks to migrate the database before and after each test.
      *
      * @param  string|array<string, mixed>  $paths
+     * @param  bool                         $rollback
      * @return void
      *
      * @throws \InvalidArgumentException
      */
-    protected function loadMigrationsFrom($paths): void
+    protected function loadMigrationsFrom($paths, bool $rollback = true): void
     {
         $options = \is_array($paths) ? $paths : ['--path' => $paths];
 
@@ -30,6 +31,8 @@ trait WithLoadMigrationsFrom
 
         $this->resetApplicationArtisanCommands($this->app);
 
-        $this->beforeApplicationDestroyed(fn () => $migrator->rollback());
+        if ($rollback) {
+            $this->beforeApplicationDestroyed(fn () => $migrator->rollback());
+        }
     }
 }


### PR DESCRIPTION
I need to run migrations once and then just rollback changes in DB by transaction rollback (using DatabaseTransaction trait). So making `rollback` as optional parameter will resolve my issue.