### PR TITLE
Add possibility to avoid rollback after migration

### DIFF
--- a/src/Concerns/WithLaravelMigrations.php
+++ b/src/Concerns/WithLaravelMigrations.php
@@ -15,6 +15,22 @@ trait WithLaravelMigrations
      */
     protected function loadLaravelMigrations($database = []): void
     {
+        $migrator = $this->loadLaravelMigrationsWithoutRollback($database);
+
+        $this->beforeApplicationDestroyed(static function () use ($migrator) {
+            $migrator->rollback();
+        });
+    }
+
+    /**
+     * Migrate Laravel's default migrations without rollback.
+     *
+     * @param  string|array<string, mixed>  $database
+     *
+     * @return MigrateProcessor
+     */
+    protected function loadLaravelMigrationsWithoutRollback($database = []): MigrateProcessor
+    {
         $options = \is_array($database) ? $database : ['--database' => $database];
 
         $options['--path'] = 'migrations';
@@ -24,9 +40,7 @@ trait WithLaravelMigrations
 
         $this->resetApplicationArtisanCommands($this->app);
 
-        $this->beforeApplicationDestroyed(static function () use ($migrator) {
-            $migrator->rollback();
-        });
+        return $migrator;
     }
 
     /**
@@ -38,6 +52,22 @@ trait WithLaravelMigrations
      */
     protected function runLaravelMigrations($database = []): void
     {
+        $migrator = $this->runLaravelMigrationsWithoutRollback($database);
+
+        $this->beforeApplicationDestroyed(static function () use ($migrator) {
+            $migrator->rollback();
+        });
+    }
+
+    /**
+     * Migrate all Laravel's migrations without rollback.
+     *
+     * @param  string|array<string, mixed>  $database
+     *
+     * @return MigrateProcessor
+     */
+    protected function runLaravelMigrationsWithoutRollback($database = []): MigrateProcessor
+    {
         $options = \is_array($database) ? $database : ['--database' => $database];
 
         $migrator = new MigrateProcessor($this, $options);
@@ -45,8 +75,6 @@ trait WithLaravelMigrations
 
         $this->resetApplicationArtisanCommands($this->app);
 
-        $this->beforeApplicationDestroyed(static function () use ($migrator) {
-            $migrator->rollback();
-        });
+        return $migrator;
     }
 }

--- a/src/Concerns/WithLoadMigrationsFrom.php
+++ b/src/Concerns/WithLoadMigrationsFrom.php
@@ -16,6 +16,22 @@ trait WithLoadMigrationsFrom
      */
     protected function loadMigrationsFrom($paths): void
     {
+        $migrator = $this->loadMigrationsWithoutRollbackFrom($paths);
+
+        $this->beforeApplicationDestroyed(static function () use ($migrator) {
+            $migrator->rollback();
+        });
+    }
+
+    /**
+     * Define hooks to migrate the database before each test without rollback after.
+     *
+     * @param  string|array<string, mixed>  $paths
+     *
+     * @return MigrateProcessor
+     */
+    protected function loadMigrationsWithoutRollbackFrom($paths): MigrateProcessor
+    {
         $options = \is_array($paths) ? $paths : ['--path' => $paths];
 
         if (isset($options['--realpath']) && ! \is_bool($options['--realpath'])) {
@@ -29,8 +45,6 @@ trait WithLoadMigrationsFrom
 
         $this->resetApplicationArtisanCommands($this->app);
 
-        $this->beforeApplicationDestroyed(static function () use ($migrator) {
-            $migrator->rollback();
-        });
+        return $migrator;
     }
 }


### PR DESCRIPTION
I need to run migrations once and then just rollback changes in DB by transaction rollback (using DatabaseTransaction trait). So making rollback as optional parameter will resolve my issue.