### PR TITLE
Fix testbench failures on Windows

### DIFF
--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -47,7 +47,7 @@ abstract class TestCase extends PHPUnit implements Contracts\TestCase
      */
     protected function setUp(): void
     {
-        if (property_exists(TestCase::class, 'latestResponse')) {
+        if (property_exists(static::class, 'latestResponse')) {
             static::$latestResponse = null;
         }
 
@@ -93,7 +93,7 @@ abstract class TestCase extends PHPUnit implements Contracts\TestCase
      */
     public static function tearDownAfterClass(): void
     {
-        if (property_exists(TestCase::class, 'latestResponse')) {
+        if (property_exists(static::class, 'latestResponse')) {
             static::$latestResponse = null;
         }
 

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -47,7 +47,9 @@ abstract class TestCase extends PHPUnit implements Contracts\TestCase
      */
     protected function setUp(): void
     {
-        static::$latestResponse = null;
+        if (property_exists(TestCase::class, 'latestResponse')) {
+            static::$latestResponse = null;
+        }
 
         $this->setUpTheTestEnvironment();
     }
@@ -91,7 +93,9 @@ abstract class TestCase extends PHPUnit implements Contracts\TestCase
      */
     public static function tearDownAfterClass(): void
     {
-        static::$latestResponse = null;
+        if (property_exists(TestCase::class, 'latestResponse')) {
+            static::$latestResponse = null;
+        }
 
         (function () {
             $this->classDocBlocks = [];


### PR DESCRIPTION
## About

Access to the static variable from trait breaks Testbench on Windows:

![error](https://user-images.githubusercontent.com/37669560/192751819-c6e5a9d2-ea6f-4689-a4f7-3218d07a6d10.png)

Error exception:
```
PHPUnit\Framework\ExceptionWrapper 

Access to undeclared static property P\Tests\Unit\ClassTest::$latestResponse
```

Adding the check for property existence resolves the problem.