### PR TITLE
Fix missing Illuminate\Support\Arr import in trait HandlesTestFailures

### DIFF
--- a/src/Concerns/HandlesTestFailures.php
+++ b/src/Concerns/HandlesTestFailures.php
@@ -3,6 +3,7 @@
 namespace Orchestra\Testbench\Concerns;
 
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Arr;
 use Illuminate\Testing\AssertableJsonString;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Util\Annotation\Registry;


### PR DESCRIPTION
Fix error `Class "Orchestra\Testbench\Concerns\Arr" not found` when running tests with errors.

https://github.com/orchestral/testbench-core/blob/baac2d1c30bc7a06c29ae3798442ad92910f9920/src/Concerns/HandlesTestFailures.php#L89