### PR TITLE
Define default enviroment before custom

### DIFF
--- a/src/Concerns/CreatesApplication.php
+++ b/src/Concerns/CreatesApplication.php
@@ -327,12 +327,13 @@ trait CreatesApplication
             $app->register('Illuminate\Database\Eloquent\LegacyFactoryServiceProvider');
         }
 
+        $this->defineEnvironment($app);
+
         if (method_exists($this, 'parseTestMethodAnnotations')) {
             $this->parseTestMethodAnnotations($app, 'environment-setup');
             $this->parseTestMethodAnnotations($app, 'define-env');
         }
 
-        $this->defineEnvironment($app);
         $this->getEnvironmentSetUp($app);
 
         $this->resolveApplicationRateLimiting($app);


### PR DESCRIPTION
### Changes:
Calling `defineEnvironment` method before calling methods in `@define-env` attributes.

### Reason:
This change grants ability to define default environment in `defineEnvironment` method and override it with `@define-env`.