### PR TITLE
[8.x] Adds PHPUnit 10 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "mockery/mockery": "^1.5.1",
         "orchestra/canvas": "^8.0",
         "phpstan/phpstan": "^1.8",
-        "phpunit/phpunit": "^9.5.10",
+        "phpunit/phpunit": "^9.5.27 || ^10.0",
         "symfony/process": "^6.1",
         "symfony/yaml": "^6.1",
         "vlucas/phpdotenv": "^5.4.1"
@@ -55,7 +55,7 @@
         "nunomaduro/collision": "Allow using Laravel style tests output and parallel testing (^6.2).",
         "orchestra/testbench-browser-kit": "Allow using legacy Laravel BrowserKit for testing (^7.0).",
         "orchestra/testbench-dusk": "Allow using Laravel Dusk for testing (^7.0).",
-        "phpunit/phpunit": "Allow using PHPUnit for testing (^9.5.10).",
+        "phpunit/phpunit": "Allow using PHPUnit for testing (^9.5.10 || ^10.0).",
         "symfony/yaml": "Required for CLI Commander (^6.1).",
         "vlucas/phpdotenv": "Required for CLI Commander (^5.4.1)."
     },

--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
         "nunomaduro/collision": "Allow using Laravel style tests output and parallel testing (^6.2).",
         "orchestra/testbench-browser-kit": "Allow using legacy Laravel BrowserKit for testing (^7.0).",
         "orchestra/testbench-dusk": "Allow using Laravel Dusk for testing (^7.0).",
-        "phpunit/phpunit": "Allow using PHPUnit for testing (^9.5.10 || ^10.0).",
+        "phpunit/phpunit": "Allow using PHPUnit for testing (^9.5.27 || ^10.0).",
         "symfony/yaml": "Required for CLI Commander (^6.1).",
         "vlucas/phpdotenv": "Required for CLI Commander (^5.4.1)."
     },

--- a/src/Concerns/HandlesNotSuccessfulTests.php
+++ b/src/Concerns/HandlesNotSuccessfulTests.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Orchestra\Testbench\Concerns;
+
+use Throwable;
+
+if (! class_exists(\PHPUnit\Runner\Version::class)) {
+    return;
+}
+
+if (\intval(substr(\PHPUnit\Runner\Version::id(), 0, 1)) === 1) {
+    trait HandlesNotSuccessfulTests
+    {
+        /**
+         * This method is called when a test method did not execute successfully.
+         *
+         * @param  \Throwable  $exception
+         * @return never
+         */
+        protected function onNotSuccessfulTest(Throwable $exception): never
+        {
+            parent::onNotSuccessfulTest(
+                ! \is_null(static::$latestResponse)
+                    ? static::$latestResponse->transformNotSuccessfulException($exception)
+                    : $exception
+            );
+        }
+    }
+} else {
+    trait HandlesNotSuccessfulTests
+    {
+        /**
+         * This method is called when a test method did not execute successfully.
+         *
+         * @param  \Throwable  $exception
+         * @return void
+         */
+        protected function onNotSuccessfulTest(Throwable $exception): void
+        {
+            parent::onNotSuccessfulTest(
+                ! \is_null(static::$latestResponse)
+                    ? static::$latestResponse->transformNotSuccessfulException($exception)
+                    : $exception
+            );
+        }
+    }
+}

--- a/src/Concerns/HandlesNotSuccessfulTests.php
+++ b/src/Concerns/HandlesNotSuccessfulTests.php
@@ -8,6 +8,9 @@ if (! class_exists(\PHPUnit\Runner\Version::class)) {
     return;
 }
 
+/**
+ * @TODO To be removed and use `Illuminate\Foundation\Testing\Concerns\InteractsWithNotSuccessfulTests`.
+ */
 if (\intval(substr(\PHPUnit\Runner\Version::id(), 0, 1)) === 1) {
     trait HandlesNotSuccessfulTests
     {

--- a/src/Concerns/Testing.php
+++ b/src/Concerns/Testing.php
@@ -25,6 +25,7 @@ trait Testing
     use CreatesApplication,
         HandlesAnnotations,
         HandlesDatabases,
+        HandlesNotSuccessfulTests,
         HandlesRoutes,
         WithFactories,
         WithLaravelMigrations,

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -99,19 +99,4 @@ abstract class TestCase extends PHPUnit implements Contracts\TestCase
             $this->methodDocBlocks = [];
         })->call(Registry::getInstance());
     }
-
-    /**
-     * This method is called when a test method did not execute successfully.
-     *
-     * @param  \Throwable  $exception
-     * @return void
-     */
-    protected function onNotSuccessfulTest(Throwable $exception): void
-    {
-        parent::onNotSuccessfulTest(
-            ! \is_null(static::$latestResponse)
-                ? static::$latestResponse->transformNotSuccessfulException($exception)
-                : $exception
-        );
-    }
 }


### PR DESCRIPTION
This pull request adds PHPUnit 10 support to `testbench-core` - while keeping support for PHPUnit 9. Note that this pull request, should test and released once PHPUnit 10 is out. In addition, @crynobone would be interesting to have the CI workflow running tests against both PHPUnit versions.