### PR TITLE
Fix to include all `artisan test` options

### DIFF
--- a/src/Foundation/Console/TestCommand.php
+++ b/src/Foundation/Console/TestCommand.php
@@ -70,7 +70,7 @@ class TestCommand extends Command
         return Collection::make(parent::phpunitArguments($options))
             ->reject(function ($option) {
                 return ! Str::startsWith($option, ['--configuration=']);
-            })->merge(["--configuration=$file"])
+            })->merge(["--configuration={$file}"])
             ->all();
     }
 
@@ -88,7 +88,7 @@ class TestCommand extends Command
             ->reject(function (string $option) {
                 return ! Str::startsWith($option, ['--configuration=', '--runner=']);
             })->merge([
-                "--configuration=$file",
+                "--configuration={$file}",
                 "--runner=\Orchestra\Testbench\Foundation\ParallelRunner",
             ])
             ->all();

--- a/src/Foundation/Console/TestCommand.php
+++ b/src/Foundation/Console/TestCommand.php
@@ -54,7 +54,7 @@ class TestCommand extends Command
             $file = TESTBENCH_WORKING_PATH.'/phpunit.xml.dist';
         }
 
-        return $file;
+        return file_exists($file) ? $file : './';
     }
 
     /**

--- a/src/Foundation/Console/TestCommand.php
+++ b/src/Foundation/Console/TestCommand.php
@@ -43,9 +43,11 @@ class TestCommand extends Command
     }
 
     /**
+     * Get the PHPUnit configuration file path.
+     * 
      * @return string
      */
-    public function getPhpUnitFile()
+    public function phpUnitConfigurationFile()
     {
         if (! file_exists($file = TESTBENCH_WORKING_PATH.'/phpunit.xml')) {
             $file = TESTBENCH_WORKING_PATH.'/phpunit.xml.dist';
@@ -67,7 +69,7 @@ class TestCommand extends Command
             return ! Str::startsWith($option, ['--configuration=']);
         });
 
-        $file = $this->getPhpUnitFile();
+        $file = $this->phpUnitConfigurationFile();
 
         return array_merge(["--configuration=$file"], $filteredParentOptions);
     }
@@ -85,7 +87,7 @@ class TestCommand extends Command
             return ! Str::startsWith($option, ['--configuration=', '--runner=']);
         });
 
-        $file = $this->getPhpUnitFile();
+        $file = $this->phpUnitConfigurationFile();
 
         return array_merge([
             "--configuration=$file",

--- a/src/Foundation/Console/TestCommand.php
+++ b/src/Foundation/Console/TestCommand.php
@@ -2,7 +2,6 @@
 
 namespace Orchestra\Testbench\Foundation\Console;
 
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use NunoMaduro\Collision\Adapters\Laravel\Commands\TestCommand as Command;
 
@@ -48,9 +47,10 @@ class TestCommand extends Command
      */
     public function getPhpUnitFile()
     {
-        if (!file_exists($file = TESTBENCH_WORKING_PATH . '/phpunit.xml')) {
-            $file = TESTBENCH_WORKING_PATH . '/phpunit.xml.dist';
+        if (! file_exists($file = TESTBENCH_WORKING_PATH.'/phpunit.xml')) {
+            $file = TESTBENCH_WORKING_PATH.'/phpunit.xml.dist';
         }
+
         return $file;
     }
 
@@ -60,7 +60,6 @@ class TestCommand extends Command
      * @param  array  $options
      * @return array
      */
-
     protected function phpunitArguments($options)
     {
         $parentOptions = parent::phpunitArguments($options);
@@ -70,8 +69,7 @@ class TestCommand extends Command
 
         $file = $this->getPhpUnitFile();
 
-        return array_merge(["--configuration=$file",], $filteredParentOptions);
-
+        return array_merge(["--configuration=$file"], $filteredParentOptions);
     }
 
     /**
@@ -84,7 +82,7 @@ class TestCommand extends Command
     {
         $parentOptions = parent::paratestArguments($options);
         $filteredParentOptions = array_filter($parentOptions, function (string $option) {
-            return ! Str::startsWith($option, ['--configuration=','--runner=']);
+            return ! Str::startsWith($option, ['--configuration=', '--runner=']);
         });
 
         $file = $this->getPhpUnitFile();

--- a/src/Foundation/Console/TestCommand.php
+++ b/src/Foundation/Console/TestCommand.php
@@ -71,7 +71,7 @@ class TestCommand extends Command
 
         return Collection::make(parent::phpunitArguments($options))
             ->reject(function ($option) {
-                return ! Str::startsWith($option, ['--configuration=']);
+                return Str::startsWith($option, ['--configuration=']);
             })->merge(["--configuration={$file}"])
             ->all();
     }
@@ -88,7 +88,7 @@ class TestCommand extends Command
 
         return Collection::make(parent::paratestArguments($options))
             ->reject(function (string $option) {
-                return ! Str::startsWith($option, ['--configuration=', '--runner=']);
+                return Str::startsWith($option, ['--configuration=', '--runner=']);
             })->merge([
                 "--configuration={$file}",
                 "--runner=\Orchestra\Testbench\Foundation\ParallelRunner",

--- a/src/Foundation/Console/TestCommand.php
+++ b/src/Foundation/Console/TestCommand.php
@@ -15,9 +15,11 @@ class TestCommand extends Command
      */
     protected $signature = 'package:test
         {--without-tty : Disable output to TTY}
-        {--coverage : Indicates whether the coverage information should be collected}
-        {--min= : Indicates the minimum threshold enforcement for coverage}
-        {--parallel : Indicates if the tests should run in parallel}
+        {--compact : Indicates whether the compact printer should be used}
+        {--coverage : Indicates whether code coverage information should be collected}
+        {--min= : Indicates the minimum threshold enforcement for code coverage}
+        {--p|parallel : Indicates if the tests should run in parallel}
+        {--profile : Lists top 10 slowest tests}
         {--recreate-databases : Indicates if the test databases should be re-created}
         {--drop-databases : Indicates if the test databases should be dropped}
     ';
@@ -45,7 +47,7 @@ class TestCommand extends Command
 
     /**
      * Get the PHPUnit configuration file path.
-     * 
+     *
      * @return string
      */
     public function phpUnitConfigurationFile()

--- a/src/Foundation/Console/TestCommand.php
+++ b/src/Foundation/Console/TestCommand.php
@@ -84,7 +84,7 @@ class TestCommand extends Command
     {
         $file = $this->phpUnitConfigurationFile();
 
-        return Collection::make(parent::phpunitArguments($options))
+        return Collection::make(parent::paratestArguments($options))
             ->reject(function (string $option) {
                 return ! Str::startsWith($option, ['--configuration=', '--runner=']);
             })->merge([


### PR DESCRIPTION
We propose the following changes due to some inadequacies of the following command :

`sail php ./vendor/bin/testbench package:test --coverage --min=90 --parallel`

More specifically, although we have setted the Xdebug mode in to our .env file `XDEBUG_MODE=develop,debug,coverage`,  by executing the above command, we receive the following error : 

```
  WARN  Unable to get coverage using Xdebug. Did you set Xdebug's coverage mode?

  FAIL  Code coverage below expected: 0.0 %. Minimum: 90.0 %.
```

After a deep searching, we noticed the following points which cause the problem and proceeded to fixes

**Flow** 

1. The `package:test` command (path :` testbench-core/src/Foundation/Console/TestCommand`) extends `NunoMaduro\Collision\Adapters\Laravel\Commands\TestCommand`
2. `package:test` (`testbench-core/src/Foundation/Console/TestCommand`) overrides **paratestArguments** method and here it's the main issue

If we compare the two `paratestArguments` functions between child (testbench) & parent (numomanduro), we can see that there are some basics differences

![Screenshot from 2023-01-27 12-30-41](https://user-images.githubusercontent.com/115797465/215071891-abce7eac-8b4f-44b7-acaf-a8c4b082fe9d.png)

Due to the above, the options that arrive in initialization of process, are the following :

![Screenshot from 2023-01-27 12-48-20(2)](https://user-images.githubusercontent.com/115797465/215071935-70068c24-6aa9-419d-a0b8-3b905729ce3b.png)


As you can see **there are no information about the coverage**, despite the fact that we have included it, in command options.
Maybe this occurred after some updates in `NunoMaduro` which were not noticed or followed.

So, in order `package-test` command, to pass the correct options, we submit this solution where, the child method, pulls all the parent's arguments, and overrides only the configuration file and runner.

In this way, we ensure, we respect the `artisan test` arguments  

![Screenshot from 2023-01-27 14-31-03](https://user-images.githubusercontent.com/115797465/215088114-17b5a8eb-8fbb-44df-a340-ff449b63d28b.png)


having the right results

![Screenshot from 2023-01-27 12-56-41](https://user-images.githubusercontent.com/115797465/215072014-4c05fa89-454a-4f26-a219-280457084e5c.png)

<br>
We also added the same logic, in `phpunitArguments` function, which takes place for sequential testing.

Hope these changes and information were found helpful and acceptable.

Co-authored-by: @GeoSot