### PR TITLE
Check if backup file exists before restoring

### DIFF
--- a/src/Foundation/Console/Concerns/CopyTestbenchFiles.php
+++ b/src/Foundation/Console/Concerns/CopyTestbenchFiles.php
@@ -34,7 +34,9 @@ trait CopyTestbenchFiles
             $filesystem->copy($testbenchFile, "{$testbenchFile}.backup");
 
             $this->beforeTerminating(function () use ($filesystem, $testbenchFile) {
-                $filesystem->move("{$testbenchFile}.backup", $testbenchFile);
+                if ($filesystem->exists("{$testbenchFile}.backup")) {
+                    $filesystem->move("{$testbenchFile}.backup", $testbenchFile);
+                }
             });
         }
 


### PR DESCRIPTION
I have a scenario where two commands are run simultaneously via the `testbench` CLI. This means that one process will clean up the `testbench.yaml.backup` file, causing the second process to trigger an error when it tries to clean it up, too. I know this is a very very edge case, but this PR adds an additional check to the `beforeTerminating` callback to ensure that the backup file still exists before restoring it.