### PR TITLE
fix: testbench should not execute the default Laravel migrations

### DIFF
--- a/src/Foundation/TestbenchServiceProvider.php
+++ b/src/Foundation/TestbenchServiceProvider.php
@@ -18,10 +18,6 @@ class TestbenchServiceProvider extends ServiceProvider
             config(['database.default' => 'testing']);
         }
 
-        if (file_exists($this->app->basePath('migrations'))) {
-            $this->loadMigrationsFrom($this->app->basePath('migrations'));
-        }
-
         if ($this->app->runningInConsole()) {
             $this->commands([
                 $this->isCollisionDependenciesInstalled()


### PR DESCRIPTION
The documentation states that the testbench should not execute the default Laravel migrations. When the Laravel migration process runs automatically during `./vendor/bin/testbench migrate` command, it already causes some of our PHP packages to fail to migrate and run unit test.

> By default Testbench doesn't execute the default Laravel migrations which include users and password_resets table.
> ref: https://packages.tools/testbench/basic/define-databases.html#manually-execute-migrations