### PR TITLE
Workbench Improvements

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,7 +10,6 @@ parameters:
 
   ignoreErrors:
     - '#Unsafe usage of new static#'
-    - '#Access to an undefined static property static\(Orchestra\\Testbench\\Foundation\\Application\)::\$cachedTestCaseUses.#'
 
   excludePaths:
     - src/Exceptions/DeprecatedException.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,6 +10,7 @@ parameters:
 
   ignoreErrors:
     - '#Unsafe usage of new static#'
+    - '#Access to an undefined static property static\(Orchestra\\Testbench\\Foundation\\Application\)::\$cachedTestCaseUses.#'
 
   excludePaths:
     - src/Exceptions/DeprecatedException.php

--- a/src/Concerns/CreatesApplication.php
+++ b/src/Concerns/CreatesApplication.php
@@ -10,7 +10,6 @@ use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\RateLimiter;
 use Orchestra\Testbench\Bootstrap\LoadEnvironmentVariables;
 use Orchestra\Testbench\Foundation\PackageManifest;
-use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 
 /**
  * @property bool|null $enablesPackageDiscoveries
@@ -400,20 +399,6 @@ trait CreatesApplication
     final protected function resetApplicationArtisanCommands($app)
     {
         $app['Illuminate\Contracts\Console\Kernel']->setArtisan(null);
-    }
-
-    /**
-     * Determine if the trait is used within testing.
-     *
-     * @return bool
-     */
-    public function isRunningTestCase(): bool
-    {
-        return $this instanceof PHPUnitTestCase
-            || (
-                property_exists($this, 'cachedTestCaseUses')
-                && isset(static::$cachedTestCaseUses[Testing::class] // @phpstan-ignore-line
-                ));
     }
 
     /**

--- a/src/Concerns/CreatesApplication.php
+++ b/src/Concerns/CreatesApplication.php
@@ -335,7 +335,7 @@ trait CreatesApplication
      */
     protected function resolveApplicationBootstrappers($app)
     {
-        if ($this instanceof PHPUnitTestCase) {
+        if ($this->isRunningTestCase()) {
             $app->make('Orchestra\Testbench\Bootstrap\HandleExceptions', ['testbench' => $this])->bootstrap($app);
         } else {
             $app->make('Illuminate\Foundation\Bootstrap\HandleExceptions')->bootstrap($app);
@@ -400,6 +400,16 @@ trait CreatesApplication
     final protected function resetApplicationArtisanCommands($app)
     {
         $app['Illuminate\Contracts\Console\Kernel']->setArtisan(null);
+    }
+
+    /**
+     * Determine if the trait is used within testing.
+     *
+     * @return bool
+     */
+    public function isRunningTestCase(): bool
+    {
+        return $this instanceof PHPUnitTestCase;
     }
 
     /**

--- a/src/Concerns/CreatesApplication.php
+++ b/src/Concerns/CreatesApplication.php
@@ -410,7 +410,10 @@ trait CreatesApplication
     public function isRunningTestCase(): bool
     {
         return $this instanceof PHPUnitTestCase
-            || (property_exists($this, 'cachedTestCaseUses') && isset(static::$cachedTestCaseUses[Testing::class]));
+            || (
+                property_exists($this, 'cachedTestCaseUses')
+                && isset(static::$cachedTestCaseUses[Testing::class] // @phpstan-ignore-line
+                ));
     }
 
     /**

--- a/src/Concerns/CreatesApplication.php
+++ b/src/Concerns/CreatesApplication.php
@@ -409,7 +409,8 @@ trait CreatesApplication
      */
     public function isRunningTestCase(): bool
     {
-        return $this instanceof PHPUnitTestCase;
+        return $this instanceof PHPUnitTestCase
+            || (property_exists($this, 'cachedTestCaseUses') && isset(static::$cachedTestCaseUses[Testing::class]));
     }
 
     /**

--- a/src/Concerns/InteractsWithPHPUnit.php
+++ b/src/Concerns/InteractsWithPHPUnit.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Orchestra\Testbench\Concerns;
+
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+
+trait InteractsWithPHPUnit
+{
+    /**
+     * The cached uses for test case.
+     *
+     * @var array<class-string, class-string>
+     */
+    protected static $cachedTestCaseUses = [];
+
+    /**
+     * Determine if the trait is used within testing.
+     *
+     * @return bool
+     */
+    public function isRunningTestCase(): bool
+    {
+        return $this instanceof PHPUnitTestCase || static::usesTestingConcern();
+    }
+
+    /**
+     * Determine if the trait is used Orchestra\Testbench\Concerns\Testing trait.
+     *
+     * @return bool
+     */
+    public static function usesTestingConcern(): bool
+    {
+        return isset(static::$cachedTestCaseUses[Testing::class]);
+    }
+
+    /**
+     * Prepare the testing environment before the running the test case.
+     *
+     * @return void
+     */
+    public static function setupBeforeClassUsingPHPUnit(): void
+    {
+        /** @var array<class-string, class-string> $uses */
+        $uses = array_flip(class_uses_recursive(static::class));
+
+        static::$cachedTestCaseUses = $uses;
+    }
+
+    /**
+     * Clean up the testing environment before the next test case.
+     *
+     * @return void
+     */
+    public static function teardownAfterClassUsingPHPUnit(): void
+    {
+        static::$cachedTestCaseUses = [];
+    }
+}

--- a/src/Concerns/InteractsWithWorkbench.php
+++ b/src/Concerns/InteractsWithWorkbench.php
@@ -7,6 +7,8 @@ use Orchestra\Testbench\Foundation\Config;
 
 trait InteractsWithWorkbench
 {
+    use InteractsWithPHPUnit;
+
     /**
      * The cached test case configuration.
      *
@@ -21,6 +23,10 @@ trait InteractsWithWorkbench
      */
     public static function applicationBasePathUsingWorkbench()
     {
+        if (! static::usesTestingConcern()) {
+            return null;
+        }
+
         return $_ENV['APP_BASE_PATH'] ?? $_ENV['TESTBENCH_APP_BASE_PATH'] ?? null;
     }
 
@@ -31,7 +37,11 @@ trait InteractsWithWorkbench
      */
     public function ignorePackageDiscoveriesFromUsingWorkbench()
     {
-        if (property_exists($this, 'enablesPackageDiscoveries') && $this->enablesPackageDiscoveries === true) {
+        if (
+            $this->isRunningTestCase()
+            && property_exists($this, 'enablesPackageDiscoveries')
+            && $this->enablesPackageDiscoveries === true
+        ) {
             return static::$cachedConfigurationForWorkbench?->getExtraAttributes()['dont-discover'] ?? [];
         }
 
@@ -46,7 +56,10 @@ trait InteractsWithWorkbench
      */
     protected function getPackageBootstrappersUsingWorkbench($app)
     {
-        if (empty($bootstrappers = (static::$cachedConfigurationForWorkbench?->getExtraAttributes()['bootstrappers'] ?? null))) {
+        if (
+            ! $this->isRunningTestCase()
+            || empty($bootstrappers = (static::$cachedConfigurationForWorkbench?->getExtraAttributes()['bootstrappers'] ?? null))
+        ) {
             return null;
         }
 
@@ -61,7 +74,10 @@ trait InteractsWithWorkbench
      */
     protected function getPackageProvidersUsingWorkbench($app)
     {
-        if (empty($providers = (static::$cachedConfigurationForWorkbench?->getExtraAttributes()['providers'] ?? null))) {
+        if (
+            ! $this->isRunningTestCase()
+            || empty($providers = (static::$cachedConfigurationForWorkbench?->getExtraAttributes()['providers'] ?? null))
+        ) {
             return null;
         }
 
@@ -83,8 +99,7 @@ trait InteractsWithWorkbench
 
         if (
             ! \is_null($config['laravel'])
-            && property_exists(static::class, 'cachedTestCaseUses')
-            && isset(static::$cachedTestCaseUses[WithWorkbench::class]) // @phpstan-ignore-line
+            && isset(static::$cachedTestCaseUses[WithWorkbench::class])
         ) {
             $_ENV['TESTBENCH_APP_BASE_PATH'] = $config['laravel'];
         }

--- a/src/Concerns/InteractsWithWorkbench.php
+++ b/src/Concerns/InteractsWithWorkbench.php
@@ -81,9 +81,11 @@ trait InteractsWithWorkbench
 
         $config = Config::loadFromYaml($workingPath);
 
+        ray(static::$cachedTestCaseUses);
+
         if (
             ! \is_null($config['laravel'])
-            && property_exists(static, 'cachedTestCaseUses')
+            && property_exists(static::class, 'cachedTestCaseUses')
             && isset(static::$cachedTestCaseUses[WithWorkbench::class])
         ) {
             $_ENV['TESTBENCH_APP_BASE_PATH'] = $config['laravel'];

--- a/src/Concerns/InteractsWithWorkbench.php
+++ b/src/Concerns/InteractsWithWorkbench.php
@@ -81,7 +81,11 @@ trait InteractsWithWorkbench
 
         $config = Config::loadFromYaml($workingPath);
 
-        if (! \is_null($config['laravel'])) {
+        if (
+            ! \is_null($config['laravel'])
+            && $this->isRunningTestCase()
+            && isset(static::$cachedTestCaseUses[WithWorkbench::class])
+        ) {
             $_ENV['TESTBENCH_APP_BASE_PATH'] = $config['laravel'];
         }
 

--- a/src/Concerns/InteractsWithWorkbench.php
+++ b/src/Concerns/InteractsWithWorkbench.php
@@ -84,7 +84,7 @@ trait InteractsWithWorkbench
         if (
             ! \is_null($config['laravel'])
             && property_exists(static::class, 'cachedTestCaseUses')
-            && isset(static::$cachedTestCaseUses[WithWorkbench::class])
+            && isset(static::$cachedTestCaseUses[WithWorkbench::class]) // @phpstan-ignore-line
         ) {
             $_ENV['TESTBENCH_APP_BASE_PATH'] = $config['laravel'];
         }

--- a/src/Concerns/InteractsWithWorkbench.php
+++ b/src/Concerns/InteractsWithWorkbench.php
@@ -83,7 +83,7 @@ trait InteractsWithWorkbench
 
         if (
             ! \is_null($config['laravel'])
-            && $this->isRunningTestCase()
+            && property_exists(static, 'cachedTestCaseUses')
             && isset(static::$cachedTestCaseUses[WithWorkbench::class])
         ) {
             $_ENV['TESTBENCH_APP_BASE_PATH'] = $config['laravel'];

--- a/src/Concerns/InteractsWithWorkbench.php
+++ b/src/Concerns/InteractsWithWorkbench.php
@@ -81,8 +81,6 @@ trait InteractsWithWorkbench
 
         $config = Config::loadFromYaml($workingPath);
 
-        ray(static::$cachedTestCaseUses);
-
         if (
             ! \is_null($config['laravel'])
             && property_exists(static::class, 'cachedTestCaseUses')

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -135,9 +135,9 @@ abstract class TestCase extends PHPUnit\TestCase implements Contracts\TestCase
         /** @var array<class-string, class-string> $uses */
         $uses = array_flip(class_uses_recursive(static::class));
 
-        static::setupBeforeClassUsingWorkbench();
-
         static::$cachedTestCaseUses = $uses;
+
+        static::setupBeforeClassUsingWorkbench();
     }
 
     /**

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -40,13 +40,6 @@ abstract class TestCase extends PHPUnit\TestCase implements Contracts\TestCase
     protected $enablesPackageDiscoveries = false;
 
     /**
-     * The cached uses for test case.
-     *
-     * @var array<class-string, class-string>
-     */
-    protected static $cachedTestCaseUses = [];
-
-    /**
      * Setup the test environment.
      *
      * @return void
@@ -107,6 +100,8 @@ abstract class TestCase extends PHPUnit\TestCase implements Contracts\TestCase
             Concerns\HandlesAnnotations::class,
             Concerns\HandlesDatabases::class,
             Concerns\HandlesRoutes::class,
+            Concerns\InteractsWithPHPUnit::class,
+            Concerns\InteractsWithWorkbench::class,
             Concerns\Testing::class,
             Concerns\WithFactories::class,
             Concerns\WithLaravelMigrations::class,
@@ -132,12 +127,13 @@ abstract class TestCase extends PHPUnit\TestCase implements Contracts\TestCase
      */
     public static function setUpBeforeClass(): void
     {
+        static::setupBeforeClassUsingPHPUnit();
+        static::setupBeforeClassUsingWorkbench();
+
         /** @var array<class-string, class-string> $uses */
         $uses = array_flip(class_uses_recursive(static::class));
 
         static::$cachedTestCaseUses = $uses;
-
-        static::setupBeforeClassUsingWorkbench();
     }
 
     /**
@@ -150,7 +146,6 @@ abstract class TestCase extends PHPUnit\TestCase implements Contracts\TestCase
         static::$latestResponse = null;
 
         static::teardownAfterClassUsingWorkbench();
-
-        static::$cachedTestCaseUses = [];
+        static::teardownAfterClassUsingPHPUnit();
     }
 }

--- a/src/Workbench/Http/Middleware/CatchDefaultRoute.php
+++ b/src/Workbench/Http/Middleware/CatchDefaultRoute.php
@@ -19,10 +19,8 @@ class CatchDefaultRoute
     {
         $workbench = workbench();
 
-        if ($request->decodedPath() === '/' && ! \is_null($workbench['user'])) {
-            return redirect(
-                \is_null($request->user()) ? '/_workbench' : $workbench['start']
-            );
+        if ($request->decodedPath() === '/' && ! \is_null($workbench['user']) && \is_null($request->user())) {
+            return redirect('/_workbench');
         }
 
         $response = $next($request);


### PR DESCRIPTION
* Add `CreatesApplication::isRunningTestCase()` method.
* Configure `TESTBENCH_APP_BASE_PATH` environment variable only when running under tests.
* Redirect to `workbench.start` path when accessing the `/` route return `404`.