### PR TITLE
Add `Composer\Config::disableProcessTimeout()` when running `serve`

### DIFF
--- a/src/Foundation/Console/ServeCommand.php
+++ b/src/Foundation/Console/ServeCommand.php
@@ -22,7 +22,7 @@ class ServeCommand extends Command
     {
         if (
             class_exists(ComposerConfig::class, false)
-            && method_exists(ComposerConfig::class, 'disableProcessTimeout')
+            && method_exists(ComposerConfig::class, 'disableProcessTimeout') // @phpstan-ignore-line
         ) {
             ComposerConfig::disableProcessTimeout();
         }

--- a/src/Foundation/Console/ServeCommand.php
+++ b/src/Foundation/Console/ServeCommand.php
@@ -2,6 +2,7 @@
 
 namespace Orchestra\Testbench\Foundation\Console;
 
+use Composer\Config as ComposerConfig;
 use Illuminate\Foundation\Console\ServeCommand as Command;
 use Orchestra\Testbench\Foundation\Events\ServeCommandEnded;
 use Orchestra\Testbench\Foundation\Events\ServeCommandStarted;
@@ -19,6 +20,13 @@ class ServeCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        if (
+            class_exists(ComposerConfig::class, false)
+            && method_exists(ComposerConfig::class, 'disableProcessTimeout')
+        ) {
+            ComposerConfig::disableProcessTimeout();
+        }
+
         /** @phpstan-ignore-next-line */
         $_ENV['TESTBENCH_WORKING_PATH'] = TESTBENCH_WORKING_PATH;
 


### PR DESCRIPTION
Avoid following issues:

```
The following exception is caused by a process timeout
Check https://getcomposer.org/doc/06-config.md#process-timeout for details

In Process.php line 1204:
                                                                                                                                               
  The process "'/opt/homebrew/Cellar/php@8.1/8.1.17/bin/php' -d allow_url_fopen='1' -d disable_functions='' -d memory_limit='1536M' vendor/bi  
  n/testbench serve" exceeded the timeout of 300 seconds.                                                                                      
```