### PR TITLE
Allow using `LOG_DEPRECATIONS_WHILE_TESTING` environment variable

### DIFF
--- a/src/Bootstrap/HandleExceptions.php
+++ b/src/Bootstrap/HandleExceptions.php
@@ -99,6 +99,6 @@ final class HandleExceptions extends \Illuminate\Foundation\Bootstrap\HandleExce
     {
         return ! class_exists(LogManager::class)
             || ! self::$app->hasBeenBootstrapped()
-            || (Env::get('LOG_DEPRECATIONS_WHILE_TESTING', true) !== false);
+            || ! Env::get('LOG_DEPRECATIONS_WHILE_TESTING', true);
     }
 }

--- a/src/Bootstrap/HandleExceptions.php
+++ b/src/Bootstrap/HandleExceptions.php
@@ -99,5 +99,6 @@ final class HandleExceptions extends \Illuminate\Foundation\Bootstrap\HandleExce
     {
         return ! class_exists(LogManager::class)
             || ! self::$app->hasBeenBootstrapped();
+            || Env::get('LOG_DEPRECATIONS_WHILE_TESTING', true) !== false;
     }
 }

--- a/src/Bootstrap/HandleExceptions.php
+++ b/src/Bootstrap/HandleExceptions.php
@@ -98,7 +98,7 @@ final class HandleExceptions extends \Illuminate\Foundation\Bootstrap\HandleExce
     protected function shouldIgnoreDeprecationErrors()
     {
         return ! class_exists(LogManager::class)
-            || ! self::$app->hasBeenBootstrapped();
-            || Env::get('LOG_DEPRECATIONS_WHILE_TESTING', true) !== false;
+            || ! self::$app->hasBeenBootstrapped()
+            || (Env::get('LOG_DEPRECATIONS_WHILE_TESTING', true) !== false);
     }
 }


### PR DESCRIPTION
This matches laravel/framework#49457 feature except Testbench still logs deprecation by default and you can disable it by adding `LOG_DEPRECATIONS_WHILE_TESTING=(false)`