### PR TITLE
[9.x] Removes custom `HandleExceptions::flushState`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",
-        "laravel/framework": "dev-feat/adds-phpunit11-support",
+        "laravel/framework": "dev-feat/adds-phpunit11-support as 11.0-dev",
         "laravel/pint": "^1.6",
         "mockery/mockery": "^1.6",
         "phpstan/phpstan": "^1.10.50",

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",
-        "laravel/framework": "^11.0",
+        "laravel/framework": "dev-feat/adds-phpunit11-support",
         "laravel/pint": "^1.6",
         "mockery/mockery": "^1.6",
         "phpstan/phpstan": "^1.10.50",

--- a/src/Bootstrap/HandleExceptions.php
+++ b/src/Bootstrap/HandleExceptions.php
@@ -86,17 +86,4 @@ final class HandleExceptions extends \Illuminate\Foundation\Bootstrap\HandleExce
             || ! self::$app->hasBeenBootstrapped()
             || ! Env::get('LOG_DEPRECATIONS_WHILE_TESTING', true);
     }
-
-    /**
-     * Flush the boostrap's global state.
-     *
-     * @return void
-     */
-    public static function flushState(): void
-    {
-        self::forgetApp();
-
-        restore_error_handler();
-        restore_exception_handler();
-    }
 }

--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -3,6 +3,7 @@
 namespace Orchestra\Testbench\Foundation;
 
 use Illuminate\Console\Application as Artisan;
+use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
 use Illuminate\Foundation\Configuration\ApplicationBuilder;
 use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
@@ -11,7 +12,6 @@ use Illuminate\Queue\Queue;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Sleep;
 use Illuminate\View\Component;
-use Orchestra\Testbench\Bootstrap\HandleExceptions;
 use Orchestra\Testbench\Concerns\CreatesApplication;
 use Orchestra\Testbench\Contracts\Config as ConfigContract;
 use Orchestra\Testbench\Workbench\Workbench;


### PR DESCRIPTION
At https://github.com/laravel/framework/pull/49622, we are doing this job already.