### PR TITLE
Support nested configuration files

### DIFF
--- a/src/Bootstrap/LoadConfiguration.php
+++ b/src/Bootstrap/LoadConfiguration.php
@@ -57,7 +57,7 @@ class LoadConfiguration
     private function loadConfigurationFiles(Application $app, RepositoryContract $config): void
     {
         $this->extendsLoadedConfiguration(
-            LazyCollection::make(function () use ($app) {
+            LazyCollection::make(static function () use ($app) {
                 $path = is_dir($app->basePath('config'))
                     ? $app->basePath('config')
                     : default_skeleton_path('config');
@@ -65,6 +65,7 @@ class LoadConfiguration
                 if (\is_string($path)) {
                     foreach (Finder::create()->files()->name('*.php')->in($path) as $file) {
                         $directory = $this->getNestedDirectory($file, $path);
+
                         yield $directory.basename($file->getRealPath(), '.php') => $file->getRealPath();
                     }
                 }
@@ -83,7 +84,7 @@ class LoadConfiguration
      * @param  string  $configPath
      * @return string
      */
-    protected function getNestedDirectory(SplFileInfo $file, $configPath)
+    protected function getNestedDirectory(SplFileInfo $file, string $configPath): string
     {
         $directory = $file->getPath();
 

--- a/src/Bootstrap/LoadConfiguration.php
+++ b/src/Bootstrap/LoadConfiguration.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
 use Orchestra\Testbench\Foundation\Env;
 use Symfony\Component\Finder\Finder;
+use SplFileInfo;
 
 use function Orchestra\Testbench\default_skeleton_path;
 

--- a/src/Bootstrap/LoadConfiguration.php
+++ b/src/Bootstrap/LoadConfiguration.php
@@ -65,7 +65,7 @@ class LoadConfiguration
                 if (\is_string($path)) {
                     foreach (Finder::create()->files()->name('*.php')->in($path) as $file) {
                         $directory = $this->getNestedDirectory($file, $path);
-                        yield basename($directory.$file->getRealPath(), '.php') => $file->getRealPath();
+                        yield $directory.basename($file->getRealPath(), '.php') => $file->getRealPath();
                     }
                 }
             })

--- a/src/Bootstrap/LoadConfiguration.php
+++ b/src/Bootstrap/LoadConfiguration.php
@@ -63,7 +63,8 @@ class LoadConfiguration
 
                 if (\is_string($path)) {
                     foreach (Finder::create()->files()->name('*.php')->in($path) as $file) {
-                        yield basename($file->getRealPath(), '.php') => $file->getRealPath();
+                        $directory = $this->getNestedDirectory($file, $configPath);
+                        yield basename($directory.$file->getRealPath(), '.php') => $file->getRealPath();
                     }
                 }
             })
@@ -74,6 +75,24 @@ class LoadConfiguration
         });
     }
 
+    /**
+     * Get the configuration file nesting path.
+     *
+     * @param  \SplFileInfo  $file
+     * @param  string  $configPath
+     * @return string
+     */
+    protected function getNestedDirectory(SplFileInfo $file, $configPath)
+    {
+        $directory = $file->getPath();
+
+        if ($nested = trim(str_replace($configPath, '', $directory), DIRECTORY_SEPARATOR)) {
+            $nested = str_replace(DIRECTORY_SEPARATOR, '.', $nested).'.';
+        }
+
+        return $nested;
+    }
+    
     /**
      * Resolve the configuration file.
      *

--- a/src/Bootstrap/LoadConfiguration.php
+++ b/src/Bootstrap/LoadConfiguration.php
@@ -57,7 +57,7 @@ class LoadConfiguration
     private function loadConfigurationFiles(Application $app, RepositoryContract $config): void
     {
         $this->extendsLoadedConfiguration(
-            LazyCollection::make(static function () use ($app) {
+            LazyCollection::make(function () use ($app) {
                 $path = is_dir($app->basePath('config'))
                     ? $app->basePath('config')
                     : default_skeleton_path('config');

--- a/src/Bootstrap/LoadConfiguration.php
+++ b/src/Bootstrap/LoadConfiguration.php
@@ -56,14 +56,14 @@ class LoadConfiguration
     private function loadConfigurationFiles(Application $app, RepositoryContract $config): void
     {
         $this->extendsLoadedConfiguration(
-            LazyCollection::make(static function () use ($app) {
+            LazyCollection::make(function () use ($app) {
                 $path = is_dir($app->basePath('config'))
                     ? $app->basePath('config')
                     : default_skeleton_path('config');
 
                 if (\is_string($path)) {
                     foreach (Finder::create()->files()->name('*.php')->in($path) as $file) {
-                        $directory = $this->getNestedDirectory($file, $configPath);
+                        $directory = $this->getNestedDirectory($file, $path);
                         yield basename($directory.$file->getRealPath(), '.php') => $file->getRealPath();
                     }
                 }

--- a/src/Bootstrap/LoadConfigurationWithWorkbench.php
+++ b/src/Bootstrap/LoadConfigurationWithWorkbench.php
@@ -60,7 +60,9 @@ class LoadConfigurationWithWorkbench extends LoadConfiguration
         }
 
         LazyCollection::make(function () {
-            foreach (Finder::create()->files()->name('*.php')->in(workbench_path('config')) as $file) {
+            $path = workbench_path('config');
+
+            foreach (Finder::create()->files()->name('*.php')->in($path) as $file) {
                 $directory = $this->getNestedDirectory($file, $path);
 
                 yield $directory.basename($file->getRealPath(), '.php') => $file->getRealPath();

--- a/src/Bootstrap/LoadConfigurationWithWorkbench.php
+++ b/src/Bootstrap/LoadConfigurationWithWorkbench.php
@@ -59,9 +59,11 @@ class LoadConfigurationWithWorkbench extends LoadConfiguration
             return $configurations;
         }
 
-        LazyCollection::make(static function () {
+        LazyCollection::make(function () {
             foreach (Finder::create()->files()->name('*.php')->in(workbench_path('config')) as $file) {
-                yield basename($file->getRealPath(), '.php') => $file->getRealPath();
+                $directory = $this->getNestedDirectory($file, $path);
+
+                yield $directory.basename($file->getRealPath(), '.php') => $file->getRealPath();
             }
         })->reject(static fn ($path, $key) => $configurations->has($key))
             ->each(static function ($path, $key) use ($configurations) {

--- a/tests/Workbench/DiscoversTest.php
+++ b/tests/Workbench/DiscoversTest.php
@@ -57,7 +57,6 @@ class DiscoversTest extends TestCase
         $this->assertSame(InstalledVersions::isInstalled('orchestra/workbench'), config('workbench.installed'));
 
         $this->assertSame(InstalledVersions::isInstalled('orchestra/workbench'), config('nested.workbench.installed'));
-
     }
 
     /** @test */

--- a/tests/Workbench/DiscoversTest.php
+++ b/tests/Workbench/DiscoversTest.php
@@ -55,6 +55,9 @@ class DiscoversTest extends TestCase
     public function it_can_discover_config_files()
     {
         $this->assertSame(InstalledVersions::isInstalled('orchestra/workbench'), config('workbench.installed'));
+
+        $this->assertSame(InstalledVersions::isInstalled('orchestra/workbench'), config('nested.workbench.installed'));
+
     }
 
     /** @test */

--- a/workbench/config/nested/workbench.php
+++ b/workbench/config/nested/workbench.php
@@ -1,0 +1,7 @@
+<?php
+
+use Composer\InstalledVersions;
+
+return [
+    'installed' => InstalledVersions::isInstalled('orchestra/workbench'),
+];


### PR DESCRIPTION
Nested configuration files is something that the Laravel framework supports, but the testbench doesn't.

The current behavior is that nested configuration files are loaded under the global namespaces, rather than nested in their respective namespace.

All I did in this PR was copy the relevant code from Laravel's `LoadConfiguration` class into the testbench variant.