### PR TITLE
[8.x] Fix breaking change: remove route action lookup

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -179,7 +179,6 @@ function parse_environment_variables($variables): array
 function refresh_router_lookups(Router $router): void
 {
     $router->getRoutes()->refreshNameLookups();
-    $router->getRoutes()->refreshActionLookups();
 }
 
 /**


### PR DESCRIPTION
After v8.21.0 was released, Livewire's dusk test suite started failing in CI.

I pinned it down to the addition of this method call: `$router->getRoutes()->refreshActionLookups();`.

Here's a screenshot of the error that is being thrown:

![CleanShot 2024-01-20 at 10 31 05@2x](https://github.com/orchestral/testbench-core/assets/3670578/841b4d0d-cf47-4c39-b403-3b5fe10a8374)

The problem occurs with route's registered with closures, not just controller class names:

![CleanShot 2024-01-20 at 10 31 54@2x](https://github.com/orchestral/testbench-core/assets/3670578/950ab15c-83f7-4446-883f-d9b088c0ce88)