### PR TITLE
Use MariaDB driver

### DIFF
--- a/laravel/config/database.php
+++ b/laravel/config/database.php
@@ -59,7 +59,7 @@ return [
         ],
 
         'mariadb' => [
-            'driver' => 'mysql',
+            'driver' => 'mariadb',
             'url' => env('DB_URL'),
             'host' => env('DB_HOST', '127.0.0.1'),
             'port' => env('DB_PORT', '3306'),


### PR DESCRIPTION
Laravel 11 now has a dedicated driver for MariaDB (https://github.com/laravel/framework/pull/50146).