### PR TITLE
Removed final from setUpTheTestEnvironmentTraits

### DIFF
--- a/src/Concerns/Testing.php
+++ b/src/Concerns/Testing.php
@@ -108,7 +108,7 @@ trait Testing
      * @param  array<class-string, class-string>  $uses
      * @return array<class-string, class-string>
      */
-    final protected function setUpTheTestEnvironmentTraits(array $uses): array
+    protected function setUpTheTestEnvironmentTraits(array $uses): array
     {
         if (isset($uses[WithWorkbench::class])) {
             $this->setUpWithWorkbench(); // @phpstan-ignore-line


### PR DESCRIPTION
Thank you for this very helpful package.

For my use case I need to override the loading of the RefreshDatabase and DatabaseTransition traits.

I'm working on an ArangoDB database driver for Laravel. The database requires to declare the collections (tables) you use at the start of a transaction. Which requires me to override the beginTransaction functions in those classes.

I've tried several alternative approaches without luck:
1) Just overriding beginTransaction() in my TestCase.php and using the Illuminate versions of the traits mentioned
This doesn't work as PestPHP seems to apply the traits after instantiating the class, so the trait version of the function is used.

2) Similarly using a new trait alongside the Illuminate trait within a PestPHP test file doesn't work as the function names conflict instead of override.

3) Implementing the contract
I went for this approach for earlier versions however with Laravel 11/Testbench 9 there's a type conflict with several properties such as a the application test hooks. 
Besides which, this requires to implement/duplicate a lot of code creating highly undesirable maintenance debt. For two lines of changed code. 

So, the surgical solution appears to be removing final.
I'm open to other solutions but currently I don't see any.

