### PR TITLE
Loads `defineRoutes()` within Application's booted event

### DIFF
--- a/src/Concerns/CreatesApplication.php
+++ b/src/Concerns/CreatesApplication.php
@@ -536,7 +536,9 @@ trait CreatesApplication
         }
 
         if ($this->isRunningTestCase() && static::usesTestingConcern(HandlesRoutes::class)) {
-            $this->setUpApplicationRoutes($app); // @phpstan-ignore-line
+            $app->booted(function () use ($app) {
+                $this->setUpApplicationRoutes($app); // @phpstan-ignore-line
+            });
         }
 
         $app->make('Illuminate\Foundation\Bootstrap\BootProviders')->bootstrap($app);


### PR DESCRIPTION
fixes orchestral/testbench#403