### PR TITLE
Allow #[Define] and #[DefineEnvironment] to be used on the class level

### DIFF
--- a/src/Attributes/Define.php
+++ b/src/Attributes/Define.php
@@ -6,7 +6,7 @@ use Attribute;
 use Orchestra\Testbench\Contracts\Attributes\Resolvable as ResolvableContract;
 use Orchestra\Testbench\Contracts\Attributes\TestingFeature;
 
-#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class Define implements ResolvableContract
 {
     /**

--- a/src/Attributes/DefineEnvironment.php
+++ b/src/Attributes/DefineEnvironment.php
@@ -6,7 +6,7 @@ use Attribute;
 use Closure;
 use Orchestra\Testbench\Contracts\Attributes\Actionable as ActionableContract;
 
-#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class DefineEnvironment implements ActionableContract
 {
     /**

--- a/tests/AttributeEnvironmentSetupTest.php
+++ b/tests/AttributeEnvironmentSetupTest.php
@@ -7,6 +7,7 @@ use Orchestra\Testbench\Attributes\DefineEnvironment;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 
+#[Define('env', 'firstClassConfig')]
 class AttributeEnvironmentSetupTest extends TestCase
 {
     /** {@inheritDoc} */
@@ -16,6 +17,12 @@ class AttributeEnvironmentSetupTest extends TestCase
         static::usesTestingFeature(new Define('env', 'globalConfig'));
 
         parent::setUp();
+    }
+
+    #[Test]
+    public function it_loads_class_config_helper()
+    {
+        $this->assertSame('testbench', config('testbench.class'));
     }
 
     #[Test]
@@ -57,6 +64,17 @@ class AttributeEnvironmentSetupTest extends TestCase
         $this->assertSame('testbench', config('testbench.global'));
         $this->assertNull(config('testbench.one'));
         $this->assertNull(config('testbench.two'));
+    }
+
+    /**
+     * Define environment setup.
+     *
+     * @param  Illuminate\Foundation\Application  $app
+     * @return void
+     */
+    protected function classConfig($app)
+    {
+        $app['config']->set('testbench.class', 'testbench');
     }
 
     /**

--- a/tests/AttributeEnvironmentSetupTest.php
+++ b/tests/AttributeEnvironmentSetupTest.php
@@ -7,7 +7,7 @@ use Orchestra\Testbench\Attributes\DefineEnvironment;
 use Orchestra\Testbench\TestCase;
 use PHPUnit\Framework\Attributes\Test;
 
-#[Define('env', 'firstClassConfig')]
+#[Define('env', 'classConfig')]
 class AttributeEnvironmentSetupTest extends TestCase
 {
     /** {@inheritDoc} */


### PR DESCRIPTION
I noticed a [recent Fortify change](https://github.com/laravel/fortify/commit/5c2e9cdf589e439feb1ed2911d4acc7ece0ec49e#diff-f8a6e10a7dd5c31a4f06e04b766e5251f848a4b9d9030c26435589e54ac2b074R17) uses the `#[DefineEnvironment]` attribute on the class level, but this currently has no effect.

With this change, both `#[Define]` and `#[DefineEnvironment]` can now be set on the class level.