### PR TITLE
[8.x] Inherits Attributes defined on parent TestCase

### DIFF
--- a/src/PHPUnit/AttributeParser.php
+++ b/src/PHPUnit/AttributeParser.php
@@ -27,17 +27,24 @@ class AttributeParser
     public static function forClass(string $className): array
     {
         $attributes = [];
+        $reflection = new ReflectionClass($className);
 
-        foreach ((new ReflectionClass($className))->getAttributes() as $attribute) {
-            if (! static::validAttribute($attribute->getName())) {
+        foreach ($reflection->getAttributes() as $attribute) {
+            if (!static::validAttribute($attribute->getName())) {
                 continue;
             }
 
             [$name, $instance] = static::resolveAttribute($attribute);
 
-            if (! \is_null($name) && ! \is_null($instance)) {
+            if (!\is_null($name) && !\is_null($instance)) {
                 array_push($attributes, ['key' => $name, 'instance' => $instance]);
             }
+        }
+
+        $parent = $reflection->getParentClass();
+
+        if ($parent && $parent->isSubclassOf(TestCase::class)) {
+            $attributes = [...static::forClass($parent->getName()), ...$attributes];
         }
 
         return $attributes;

--- a/src/PHPUnit/AttributeParser.php
+++ b/src/PHPUnit/AttributeParser.php
@@ -30,13 +30,13 @@ class AttributeParser
         $reflection = new ReflectionClass($className);
 
         foreach ($reflection->getAttributes() as $attribute) {
-            if (!static::validAttribute($attribute->getName())) {
+            if (! static::validAttribute($attribute->getName())) {
                 continue;
             }
 
             [$name, $instance] = static::resolveAttribute($attribute);
 
-            if (!\is_null($name) && !\is_null($instance)) {
+            if (! \is_null($name) && ! \is_null($instance)) {
                 array_push($attributes, ['key' => $name, 'instance' => $instance]);
             }
         }

--- a/tests/Attributes/AttributesInheritanceTest.php
+++ b/tests/Attributes/AttributesInheritanceTest.php
@@ -5,13 +5,21 @@ namespace Orchestra\Testbench\Tests\Attributes;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
 
-
 #[WithConfig('fake.parent_attribute', true)]
 #[WithConfig('fake.override_attribute', 'parent')]
-abstract class ParentTest extends TestCase {}
+abstract class AttributesInheritanceTestBaseTestCase extends TestCase
+{
+    /**
+     * @beforeClass
+     */
+    public static function defineTestingFeatures()
+    {
+        static::usesTestingFeature(new WithConfig('fake.override_attribute_2', 'parent'));
+    }
+}
 
 #[WithConfig('fake.override_attribute', 'child')]
-class InheritanceTest extends ParentTest
+class AttributesInheritanceTest extends AttributesInheritanceTestBaseTestCase
 {
     /** @test */
     public function it_can_see_parent_attributes() {
@@ -21,5 +29,6 @@ class InheritanceTest extends ParentTest
     /** @test */
     public function it_can_override_parent_attributes() {
         $this->assertSame('child', config('fake.override_attribute'));
+        $this->assertSame('child', config('fake.override_attribute_2'));
     }
 }

--- a/tests/Attributes/AttributesInheritanceTest.php
+++ b/tests/Attributes/AttributesInheritanceTest.php
@@ -30,12 +30,14 @@ class AttributesInheritanceTest extends AttributesInheritanceTestBaseTestCase
     }
 
     /** @test */
-    public function it_can_see_parent_attributes() {
+    public function it_can_see_parent_attributes()
+    {
         $this->assertSame(true, config('fake.parent_attribute'));
     }
 
     /** @test */
-    public function it_can_override_parent_attributes() {
+    public function it_can_override_parent_attributes()
+    {
         $this->assertSame('child', config('fake.override_attribute'));
         $this->assertSame('child', config('fake.override_attribute_2'));
     }

--- a/tests/Attributes/AttributesInheritanceTest.php
+++ b/tests/Attributes/AttributesInheritanceTest.php
@@ -21,6 +21,14 @@ abstract class AttributesInheritanceTestBaseTestCase extends TestCase
 #[WithConfig('fake.override_attribute', 'child')]
 class AttributesInheritanceTest extends AttributesInheritanceTestBaseTestCase
 {
+    /**
+     * @beforeClass
+     */
+    public static function defineChildTestingFeatures()
+    {
+        static::usesTestingFeature(new WithConfig('fake.override_attribute_2', 'child'));
+    }
+
     /** @test */
     public function it_can_see_parent_attributes() {
         $this->assertSame(true, config('fake.parent_attribute'));

--- a/tests/Attributes/InheritanceTest.php
+++ b/tests/Attributes/InheritanceTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Orchestra\Testbench\Tests\Attributes;
+
+use Orchestra\Testbench\Attributes\WithConfig;
+use Orchestra\Testbench\TestCase;
+
+
+#[WithConfig('fake.parent_attribute', true)]
+#[WithConfig('fake.override_attribute', 'parent')]
+class ParentTest extends TestCase {}
+
+#[WithConfig('fake.override_attribute', 'child')]
+class InheritanceTest extends ParentTest
+{
+    /** @test */
+    public function it_can_see_parent_attributes() {
+        $this->assertSame(true, config('fake.parent_attribute'));
+    }
+
+    /** @test */
+    public function it_can_override_parent_attributes() {
+        $this->assertSame('child', config('fake.override_attribute'));
+    }
+}

--- a/tests/Attributes/InheritanceTest.php
+++ b/tests/Attributes/InheritanceTest.php
@@ -8,7 +8,7 @@ use Orchestra\Testbench\TestCase;
 
 #[WithConfig('fake.parent_attribute', true)]
 #[WithConfig('fake.override_attribute', 'parent')]
-class ParentTest extends TestCase {}
+abstract class ParentTest extends TestCase {}
 
 #[WithConfig('fake.override_attribute', 'child')]
 class InheritanceTest extends ParentTest

--- a/tests/Attributes/UsesTestingFeaturesTest.php
+++ b/tests/Attributes/UsesTestingFeaturesTest.php
@@ -5,7 +5,7 @@ namespace Orchestra\Testbench\Tests\Attributes;
 use Orchestra\Testbench\Attributes\WithConfig;
 use Orchestra\Testbench\TestCase;
 
-abstract class BaseTestCase extends TestCase
+abstract class UsesTestingFeaturesTestBaseTestCase extends TestCase
 {
     /**
      * @beforeClass
@@ -19,7 +19,7 @@ abstract class BaseTestCase extends TestCase
 }
 
 #[WithConfig('fake.override_attribute', 'child')]
-class UsesTestingFeaturesTest extends BaseTestCase
+class UsesTestingFeaturesTest extends UsesTestingFeaturesTestBaseTestCase
 {
     /**
      * @beforeClass


### PR DESCRIPTION
When you have a starting TestCase class and many children inheriting from it, they currently don't see the parent's attributes.

This is an issue when you need to define a standard WithConfig for every test (for example you need to define the faker locale for all the tests).

This PR fixes it.