### PR TITLE
[7.x] `package:create-sqlite-db` and `package:drop-sqlite-db` improvements

### DIFF
--- a/src/Foundation/Console/CreateSqliteDbCommand.php
+++ b/src/Foundation/Console/CreateSqliteDbCommand.php
@@ -4,6 +4,7 @@ namespace Orchestra\Testbench\Foundation\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 use function Orchestra\Testbench\join_paths;
@@ -16,7 +17,9 @@ class CreateSqliteDbCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'package:create-sqlite-db {--force : Overwrite the database file}';
+    protected $signature = 'package:create-sqlite-db
+                                {--database=database.sqlite : Set the database name}
+                                {--force : Overwrite the database file}';
 
     /**
      * Execute the console command.
@@ -38,7 +41,7 @@ class CreateSqliteDbCommand extends Command
             ? join_paths($databasePath, 'database.sqlite.example')
             : (string) realpath(join_paths(__DIR__, 'stubs', 'database.sqlite.example'));
 
-        $to = join_paths($databasePath, 'database.sqlite');
+        $to = join_paths($databasePath, $this->databaseName());
 
         (new Actions\GeneratesFile(
             filesystem: $filesystem,
@@ -48,5 +51,20 @@ class CreateSqliteDbCommand extends Command
         ))->handle($from, $to);
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * Resolve the database name.
+     *
+     * @return string
+     */
+    protected function databaseName(): string
+    {
+        if (empty($database = $this->option('database'))) {
+            $database = 'database';
+        }
+
+        /** @var string $database */
+        return \sprintf('%s.sqlite', Str::before((string) $database, '.sqlite'));
     }
 }

--- a/src/Foundation/Console/DropSqliteDbCommand.php
+++ b/src/Foundation/Console/DropSqliteDbCommand.php
@@ -4,6 +4,7 @@ namespace Orchestra\Testbench\Foundation\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 use function Orchestra\Testbench\join_paths;
@@ -16,7 +17,9 @@ class DropSqliteDbCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'package:drop-sqlite-db';
+    protected $signature = 'package:drop-sqlite-db
+                                {--database=database.sqlite : Set the database name}
+                                {--all : Delete all SQLite databases}';
 
     /**
      * Execute the console command.
@@ -33,8 +36,28 @@ class DropSqliteDbCommand extends Command
             filesystem: $filesystem,
             components: $this->components,
             workingPath: $workingPath,
-        ))->handle([join_paths($databasePath, 'database.sqlite')]);
+        ))->handle(
+            match ($this->option('all')) {
+                true => [...$filesystem->glob(join_paths($databasePath, '*.sqlite'))],
+                default => [join_paths($databasePath, $this->databaseName())],
+            }
+        );
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * Resolve the database name.
+     *
+     * @return string
+     */
+    protected function databaseName(): string
+    {
+        if (empty($database = $this->option('database'))) {
+            $database = 'database';
+        }
+
+        /** @var string $database */
+        return \sprintf('%s.sqlite', Str::before((string) $database, '.sqlite'));
     }
 }


### PR DESCRIPTION

* Add `--database` option to both create and drop commands.
* Add `--all` option to drop all SQLite databases within `database` directory.

Solves #251