### PR TITLE
[7.x] Add `getApplicationBasePath()` method as replacement to `getBasePath()`

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/schema/9.5.xsd"
          backupGlobals="false"
          backupStaticAttributes="false"
          beStrictAboutTestsThatDoNotTestAnything="true"

--- a/src/Concerns/CreatesApplication.php
+++ b/src/Concerns/CreatesApplication.php
@@ -226,11 +226,9 @@ trait CreatesApplication
      */
     protected function getApplicationBasePath()
     {
-        if (method_exists($this, 'getBasePath')) {
-            return $this->getBasePath();
-        }
-
-        return static::applicationBasePath();
+        return method_exists($this, 'getBasePath')
+            ? $this->getBasePath()
+            : static::applicationBasePath();
     }
 
     /**

--- a/src/Concerns/CreatesApplication.php
+++ b/src/Concerns/CreatesApplication.php
@@ -218,12 +218,18 @@ trait CreatesApplication
     }
 
     /**
-     * Get base path.
+     * Resolve the application's base path.
+     *
+     * @api
      *
      * @return string
      */
-    protected function getBasePath()
+    protected function getApplicationBasePath()
     {
+        if (method_exists($this, 'getBasePath')) {
+            return $this->getBasePath();
+        }
+
         return static::applicationBasePath();
     }
 
@@ -261,7 +267,7 @@ trait CreatesApplication
      */
     final protected function resolveDefaultApplication()
     {
-        return new Application($this->getBasePath());
+        return new Application($this->getApplicationBasePath());
     }
 
     /**

--- a/src/Console/Commander.php
+++ b/src/Console/Commander.php
@@ -137,7 +137,7 @@ class Commander
     public function laravel()
     {
         if (! $this->app instanceof LaravelApplication) {
-            $APP_BASE_PATH = $this->getBasePath();
+            $APP_BASE_PATH = $this->getApplicationBasePath();
             $VENDOR_PATH = join_paths($this->workingPath, 'vendor');
 
             $filesystem = new Filesystem;
@@ -200,11 +200,11 @@ class Commander
     }
 
     /**
-     * Get base path.
+     * Resolve the application's base path.
      *
      * @return string
      */
-    protected function getBasePath()
+    protected function getApplicationBasePath()
     {
         $path = $this->config['laravel'] ?? null;
 
@@ -219,6 +219,8 @@ class Commander
 
     /**
      * Get the application's base path.
+     *
+     * @api
      *
      * @return string
      */

--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -293,11 +293,13 @@ class Application
     }
 
     /**
-     * Get base path.
+     * Resolve the application's base path.
+     *
+     * @api
      *
      * @return string
      */
-    protected function getBasePath()
+    protected function getApplicationBasePath()
     {
         return $this->basePath ?? static::applicationBasePath();
     }


### PR DESCRIPTION
The `getBasePath()` method will be deprecated in Testbench 10.