### PR TITLE
Fix symlink removal on Windows

### DIFF
--- a/src/Workbench/Actions/AddAssetSymlinkFolders.php
+++ b/src/Workbench/Actions/AddAssetSymlinkFolders.php
@@ -63,7 +63,7 @@ final class AddAssetSymlinkFolders
                 $to = $pair['to'];
 
                 if (is_symlink($to)) {
-                    windows_os() ? $this->files->deleteDirectory($to) : $this->files->delete($to);
+                    windows_os() ? @rmdir($to) : $this->files->delete($to);
                 } elseif ($this->files->isDirectory($to)) {
                     $this->files->deleteDirectory($to);
                 }

--- a/src/Workbench/Actions/AddAssetSymlinkFolders.php
+++ b/src/Workbench/Actions/AddAssetSymlinkFolders.php
@@ -63,7 +63,7 @@ final class AddAssetSymlinkFolders
                 $to = $pair['to'];
 
                 if (is_symlink($to)) {
-                    windows_os() ? @rmdir($to) : $this->files->delete($to);
+                    windows_os() ? $this->files->deleteDirectory($to) : $this->files->delete($to);
                 } elseif ($this->files->isDirectory($to)) {
                     $this->files->deleteDirectory($to);
                 }

--- a/src/Workbench/Actions/RemoveAssetSymlinkFolders.php
+++ b/src/Workbench/Actions/RemoveAssetSymlinkFolders.php
@@ -50,7 +50,7 @@ final class RemoveAssetSymlinkFolders
 
                 if (is_symlink($to)) {
                     return [$to, function ($to) {
-                        windows_os() ? $this->files->deleteDirectory($to) : $this->files->delete($to);
+                        windows_os() ? @rmdir($to) : $this->files->delete($to);
                     }];
                 }
 

--- a/src/Workbench/Actions/RemoveAssetSymlinkFolders.php
+++ b/src/Workbench/Actions/RemoveAssetSymlinkFolders.php
@@ -50,7 +50,7 @@ final class RemoveAssetSymlinkFolders
 
                 if (is_symlink($to)) {
                     return [$to, function ($to) {
-                        windows_os() ? @rmdir($to) : $this->files->delete($to);
+                        windows_os() ? $this->files->deleteDirectory($to) : $this->files->delete($to);
                     }];
                 }
 

--- a/tests/Workbench/ActionsTest.php
+++ b/tests/Workbench/ActionsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Orchestra\Testbench\Tests\Workbench;
+
+use Illuminate\Filesystem\Filesystem;
+use Orchestra\Testbench\Foundation\Config;
+use Orchestra\Testbench\Tests\TestCase;
+use Orchestra\Testbench\Workbench\Actions\AddAssetSymlinkFolders;
+use Orchestra\Testbench\Workbench\Actions\RemoveAssetSymlinkFolders;
+use PHPUnit\Framework\Attributes\Test;
+use function Orchestra\Sidekick\is_symlink;
+use function Orchestra\Testbench\default_skeleton_path;
+use function Orchestra\Testbench\workbench_path;
+
+class ActionsTest extends TestCase
+{
+    protected Filesystem $filesystem;
+
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filesystem = new Filesystem;
+
+        $path = default_skeleton_path();
+        $this->filesystem->copyDirectory($path.'/storage', $path.'/storage.bak');
+        $this->ensureSymlinkExists();
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $path = default_skeleton_path();
+        if (! default_skeleton_path('storage/framework')) {
+            $this->filesystem->moveDirectory($path.'/storage.bak', $path.'/storage', true);
+        } else {
+            $this->filesystem->deleteDirectory($path.'/storage.bak');
+        }
+    }
+
+    #[Test]
+    public function it_does_not_wipe_target_directory_while_recreating_asset_symlink()
+    {
+        (new AddAssetSymlinkFolders($this->filesystem, $this->getConfig()))->handle();
+        $this->assertDirectoryExists(default_skeleton_path().'/storage/framework');
+    }
+
+    #[Test]
+    public function it_does_not_wipe_target_directory_while_removing_asset_symlink()
+    {
+        (new RemoveAssetSymlinkFolders($this->filesystem, $this->getConfig()))->handle();
+        $this->assertDirectoryExists(default_skeleton_path().'/storage/framework');
+    }
+
+    protected function ensureSymlinkExists(): void
+    {
+        if (! is_symlink(workbench_path().'/storage')) {
+            $this->filesystem->link(default_skeleton_path().'/storage', workbench_path().'/storage');
+        }
+    }
+
+    protected function getConfig(): Config
+    {
+        return new Config([
+            'workbench' => [
+                'sync' => [[
+                    'from' => 'storage',
+                    'to' => 'workbench/storage',
+                    'reverse' => true,
+                ]],
+            ],
+        ]);
+    }
+}

--- a/tests/Workbench/ActionsTest.php
+++ b/tests/Workbench/ActionsTest.php
@@ -8,6 +8,7 @@ use Orchestra\Testbench\Tests\TestCase;
 use Orchestra\Testbench\Workbench\Actions\AddAssetSymlinkFolders;
 use Orchestra\Testbench\Workbench\Actions\RemoveAssetSymlinkFolders;
 use PHPUnit\Framework\Attributes\Test;
+
 use function Orchestra\Sidekick\is_symlink;
 use function Orchestra\Testbench\default_skeleton_path;
 use function Orchestra\Testbench\workbench_path;

--- a/tests/Workbench/ActionsTest.php
+++ b/tests/Workbench/ActionsTest.php
@@ -31,9 +31,9 @@ class ActionsTest extends TestCase
 
         $this->beforeApplicationDestroyed(function () use ($skeletonPath) {
             if (! default_skeleton_path('storage', 'framework')) {
-                $this->filesystem->moveDirectory(join_paths($path, 'storage.bak'), join_paths($path, 'storage'), true);
+                $this->filesystem->moveDirectory(join_paths($skeletonPath, 'storage.bak'), join_paths($skeletonPath, 'storage'), true);
             } else {
-                $this->filesystem->deleteDirectory(join_paths($path, 'storage.bak'));
+                $this->filesystem->deleteDirectory(join_paths($skeletonPath, 'storage.bak'));
             }
         });
         

--- a/tests/Workbench/ActionsTest.php
+++ b/tests/Workbench/ActionsTest.php
@@ -10,6 +10,7 @@ use Orchestra\Testbench\Workbench\Actions\RemoveAssetSymlinkFolders;
 use PHPUnit\Framework\Attributes\Test;
 
 use function Orchestra\Sidekick\is_symlink;
+use function Orchestra\Sidekick\join_paths;
 use function Orchestra\Testbench\default_skeleton_path;
 use function Orchestra\Testbench\workbench_path;
 
@@ -20,46 +21,46 @@ class ActionsTest extends TestCase
     #[\Override]
     protected function setUp(): void
     {
+        $this->filesystem = new Filesystem;
+        $skeletonPath = default_skeleton_path();
+
+        $this->afterApplicationCreated(function () use ($skeletonPath) {
+            $this->filesystem->copyDirectory(join_paths($skeletonPath, 'storage'), join_paths($skeletonPath, 'storage.bak'));
+            $this->ensureSymlinkExists();
+        });
+
+        $this->beforeApplicationDestroyed(function () use ($skeletonPath) {
+            if (! default_skeleton_path('storage', 'framework')) {
+                $this->filesystem->moveDirectory(join_paths($path, 'storage.bak'), join_paths($path, 'storage'), true);
+            } else {
+                $this->filesystem->deleteDirectory(join_paths($path, 'storage.bak'));
+            }
+        });
+        
         parent::setUp();
 
-        $this->filesystem = new Filesystem;
-
-        $path = default_skeleton_path();
-        $this->filesystem->copyDirectory($path.'/storage', $path.'/storage.bak');
-        $this->ensureSymlinkExists();
-    }
-
-    #[\Override]
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-
-        $path = default_skeleton_path();
-        if (! default_skeleton_path('storage/framework')) {
-            $this->filesystem->moveDirectory($path.'/storage.bak', $path.'/storage', true);
-        } else {
-            $this->filesystem->deleteDirectory($path.'/storage.bak');
-        }
     }
 
     #[Test]
     public function it_does_not_wipe_target_directory_while_recreating_asset_symlink()
     {
         (new AddAssetSymlinkFolders($this->filesystem, $this->getConfig()))->handle();
-        $this->assertDirectoryExists(default_skeleton_path().'/storage/framework');
+
+        $this->assertDirectoryExists(default_skeleton_path('storage', 'framework'));
     }
 
     #[Test]
     public function it_does_not_wipe_target_directory_while_removing_asset_symlink()
     {
         (new RemoveAssetSymlinkFolders($this->filesystem, $this->getConfig()))->handle();
-        $this->assertDirectoryExists(default_skeleton_path().'/storage/framework');
+
+        $this->assertDirectoryExists(default_skeleton_path('storage', 'framework'));
     }
 
     protected function ensureSymlinkExists(): void
     {
-        if (! is_symlink(workbench_path().'/storage')) {
-            $this->filesystem->link(default_skeleton_path().'/storage', workbench_path().'/storage');
+        if (! is_symlink(workbench_path('storage'))) {
+            $this->filesystem->link(default_skeleton_path('storage'), workbench_path('storage'));
         }
     }
 


### PR DESCRIPTION
This PR fixes unwanted behavior on Windows systems, where `package:purge-skeleton` command cleans up entire symlinked directory instead of just unlinking it. This is because of `deleteDirectory` implementation which iterates through directory contents without checking if containing folder is a symlink or not.
I actually think it must be fixed on Laravel side by forbidding to "dive" into symlinked directories and preferrably smoothing differences between operating systems in the aspect of symlink operation uniformity; but this must be carefully thought out.
So take this PR as a quick fix until something better comes along.