### PR TITLE
[7.x] Add `WithFixtures` to automatically loads fixtures file for test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "require": {
         "php": "^8.0",
         "composer-runtime-api": "^2.2",
-        "orchestra/sidekick": "~1.1.21|~1.2.18",
+        "orchestra/sidekick": "~1.1.22|~1.2.19",
         "symfony/deprecation-contracts": "^2.5|^3.0",
         "symfony/polyfill-php83": "^1.32"
     },

--- a/src/Concerns/InteractsWithTestCase.php
+++ b/src/Concerns/InteractsWithTestCase.php
@@ -179,6 +179,10 @@ trait InteractsWithTestCase
      */
     public static function setUpBeforeClassUsingTestCase(): void
     {
+        if (static::usesTestingConcern(WithFixtures::class)) {
+            static::setupWithFixturesForTestingEnvironment();
+        }
+
         static::resolvePhpUnitAttributesForMethod(static::class)
             ->flatten()
             ->filter(static fn ($instance) => $instance instanceof BeforeAllContract)

--- a/src/Concerns/InteractsWithTestCase.php
+++ b/src/Concerns/InteractsWithTestCase.php
@@ -180,6 +180,7 @@ trait InteractsWithTestCase
     public static function setUpBeforeClassUsingTestCase(): void
     {
         if (static::usesTestingConcern(WithFixtures::class)) {
+            /** @phpstan-ignore-next-line */
             static::setupWithFixturesForTestingEnvironment();
         }
 

--- a/src/Concerns/WithFixtures.php
+++ b/src/Concerns/WithFixtures.php
@@ -5,8 +5,16 @@ namespace Orchestra\Testbench\Concerns;
 use Illuminate\Support\Str;
 use ReflectionClass;
 
+/**
+ * @api
+ */
 trait WithFixtures
 {
+    /**
+     * Setup test case to include fixture file using ".fixtures.php" suffix if it's available.
+     *
+     * @return void
+     */
     protected static function setupWithFixturesForTestingEnvironment(): void
     {
         $reflection = new ReflectionClass(static::class);

--- a/src/Concerns/WithFixtures.php
+++ b/src/Concerns/WithFixtures.php
@@ -3,7 +3,8 @@
 namespace Orchestra\Testbench\Concerns;
 
 use Illuminate\Support\Str;
-use ReflectionClass;
+
+use function Orchestra\Sidekick\Filesystem\filename_from_classname;
 
 /**
  * @api
@@ -19,9 +20,9 @@ trait WithFixtures
      */
     protected static function setupWithFixturesForTestingEnvironment(): void
     {
-        $reflection = new ReflectionClass(static::class);
+        $classFileName = filename_from_classname(static::class);
 
-        if (! is_file($classFileName = $reflection->getFileName()) && ! str_ends_with($classFileName, '.php')) {
+        if ($classFileName === false) {
             return;
         }
 

--- a/src/Concerns/WithFixtures.php
+++ b/src/Concerns/WithFixtures.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Orchestra\Testbench\Concerns;
+
+use Illuminate\Support\Str;
+use ReflectionClass;
+
+trait WithFixtures
+{
+    protected static function setupWithFixturesForTestingEnvironment(): void
+    {
+        $reflection = new ReflectionClass(static::class);
+
+        if (! is_file($classFileName = $reflection->getFileName()) && ! str_ends_with($classFileName, '.php')) {
+            return;
+        }
+
+        if (! is_file($fixtureFileName = Str::replaceLast('.php', '.fixtures.php', $classFileName))) {
+            return;
+        }
+
+        require_once $fixtureFileName;
+    }
+}

--- a/src/Concerns/WithFixtures.php
+++ b/src/Concerns/WithFixtures.php
@@ -7,6 +7,8 @@ use ReflectionClass;
 
 /**
  * @api
+ *
+ * @codeCoverageIgnore
  */
 trait WithFixtures
 {

--- a/src/functions.php
+++ b/src/functions.php
@@ -108,11 +108,7 @@ function once($callback): Closure
  */
 function after_resolving(ApplicationContract $app, string $name, ?Closure $callback = null): void
 {
-    $app->afterResolving($name, $callback);
-
-    if ($app->resolved($name)) {
-        value($callback, $app->make($name), $app);
-    }
+    Sidekick\after_resolving($app, $name, $callback);
 }
 
 /**

--- a/tests/WithWorkbenchTest.fixtures.php
+++ b/tests/WithWorkbenchTest.fixtures.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Orchestra\Testbench\Tests\WithWorkbenchTest;
+
+use Orchestra\Testbench\Concerns\WithWorkbench;
+use Orchestra\Testbench\Contracts\Config as ConfigContract;
+
+class MergeSeedersTestStub
+{
+    use WithWorkbench;
+
+    public function __construct(protected bool $seed, protected string|false $seeders) {}
+
+    public function __invoke(ConfigContract $config)
+    {
+        return $this->mergeSeedersForWorkbench($config);
+    }
+
+    public function shouldSeed(): bool
+    {
+        return $this->seed;
+    }
+
+    public function seeder(): string|false
+    {
+        return $this->seeders;
+    }
+}

--- a/tests/WithWorkbenchTest.php
+++ b/tests/WithWorkbenchTest.php
@@ -2,6 +2,7 @@
 
 namespace Orchestra\Testbench\Tests;
 
+use Orchestra\Testbench\Concerns\WithFixtures;
 use Orchestra\Testbench\Concerns\WithWorkbench;
 use Orchestra\Testbench\Contracts\Config as ConfigContract;
 use Orchestra\Testbench\Foundation\Config;
@@ -9,6 +10,7 @@ use Orchestra\Testbench\Workbench\Workbench;
 
 class WithWorkbenchTest extends TestCase
 {
+    use WithFixtures;
     use WithWorkbench;
 
     /** @test */
@@ -71,7 +73,7 @@ class WithWorkbenchTest extends TestCase
         array|false $workbenchSeeders,
         array|false $expected
     ) {
-        $stub = new MergeSeedersTestStub($seed, $seeder);
+        $stub = new WithWorkbenchTest\MergeSeedersTestStub($seed, $seeder);
 
         $config = new Config(['seeders' => $workbenchSeeders]);
 
@@ -86,27 +88,5 @@ class WithWorkbenchTest extends TestCase
         yield [false, 'Database\Seeders\DatabaseSeeder', ['Workbench\Database\Seeders\DatabaseSeeder'], false];
         yield [true, 'Database\Seeders\DatabaseSeeder', ['Database\Seeders\DatabaseSeeder', 'Workbench\Database\Seeders\DatabaseSeeder'], ['Workbench\Database\Seeders\DatabaseSeeder']];
         yield [true, 'Workbench\Database\Seeders\DatabaseSeeder', ['Workbench\Database\Seeders\DatabaseSeeder'], false];
-    }
-}
-
-class MergeSeedersTestStub
-{
-    use WithWorkbench;
-
-    public function __construct(protected bool $seed, protected string|false $seeders) {}
-
-    public function __invoke(ConfigContract $config)
-    {
-        return $this->mergeSeedersForWorkbench($config);
-    }
-
-    public function shouldSeed(): bool
-    {
-        return $this->seed;
-    }
-
-    public function seeder(): string|false
-    {
-        return $this->seeders;
     }
 }


### PR DESCRIPTION
In most packages, you can either rely on a set of fixtures for the whole test suite, but there are also scenarios where you need to create custom fixtures for each test case, such as the following:

Given the following `tests/AuthenticateUserUsingSanctumTest.php`:

```php
<?php

namespace Tests;

class AuthenticateUserUsingSanctumTest extends \Orchestra\Testbench\TestCase
{
     public function test_it_can_login_the_user()
    {
        $user = new User([ /* ... */ ]);
    }
}

class User extends \Illuminate\Foundation\Auth\User
{
   use \Laravel\Sanctum\HasApiTokens;
}
```

Issues will start to pop out when you have another testcase that needs to create a custom `User` fixture within the same namespace as `AuthenticateUserUsingSanctumTest` class.

### Solution

Update `tests/AuthenticateUserUsingSanctumTest.php`

```diff
<?php

namespace Tests;

+use Orchestra\Testbench\Concerns\WithFixtures;

class AuthenticateUserUsingSanctumTest extends \Orchestra\Testbench\TestCase
{
+   use WithFixtures;

     public function test_it_can_login_the_user()
    {
-       $user = new User([ /* ... */ ]);
+       $user = new AuthenticateUserUsingSanctumTest\User([ /* ... */ ]);
    }
}

-class User extends \Illuminate\Foundation\Auth\User
-{
-   use \Laravel\Sanctum\HasApiTokens;
-}
```

And then add a new `tests/AuthenticateUserUsingSanctumTest.fixtures.php` with the following content:

```php
<?php

namespace Tests\AuthenticateUserUsingSanctumTest;

class User extends \Illuminate\Foundation\Auth\User
{
   use \Laravel\Sanctum\HasApiTokens;
}
```