### PR TITLE
Add `flushState()` to `FormRequest` to reset global strict mode between tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.24",
-        "laravel/framework": "^13.1.1",
+        "laravel/framework": "^13.4.0",
         "laravel/pint": "^1.24",
         "laravel/serializable-closure": "^2.0.10",
         "mockery/mockery": "^1.6.10",
@@ -56,7 +56,7 @@
     },
     "conflict": {
         "brianium/paratest": "<7.3.0|>=8.0.0",
-        "laravel/framework": "<13.1.1|>=14.0.0",
+        "laravel/framework": "<13.4.0|>=14.0.0",
         "laravel/serializable-closure": ">=2.0.0 <2.0.10|>=3.0.0",
         "nunomaduro/collision": "<8.9.0|>=9.0.0",
         "phpunit/phpunit": "<11.5.50|>=12.0.0 <12.5.8|>=13.2.0"

--- a/src/Foundation/Application.php
+++ b/src/Foundation/Application.php
@@ -15,6 +15,7 @@ use Illuminate\Foundation\Bootstrap\RegisterProviders;
 use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Foundation\Console\ChannelListCommand;
 use Illuminate\Foundation\Console\RouteListCommand;
+use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
 use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
 use Illuminate\Foundation\Http\Middleware\TrimStrings;
@@ -230,6 +231,7 @@ class Application
         ConvertEmptyStringsToNull::flushState();
         EncodedHtmlString::flushState();
         Factory::flushState();
+        FormRequest::flushState();
 
         if (! $instance instanceof Commander) {
             HandleExceptions::flushState($instance);


### PR DESCRIPTION
Reference: https://github.com/laravel/framework/pull/59574