### PR TITLE
[9.x] Fix `package:test` missing `--without-cache` option from collision v8.9.4

### DIFF
--- a/src/Foundation/Console/TestCommand.php
+++ b/src/Foundation/Console/TestCommand.php
@@ -6,8 +6,10 @@ use Illuminate\Support\Collection;
 use NunoMaduro\Collision\Adapters\Laravel\Commands\TestCommand as Command;
 use Orchestra\Sidekick\Env;
 use Orchestra\Testbench\Features\ParallelRunner;
+use Symfony\Component\Console\Input\InputOption;
 
 use function Orchestra\Sidekick\is_testbench_cli;
+use function Orchestra\Sidekick\package_version_compare;
 use function Orchestra\Testbench\defined_environment_variables;
 use function Orchestra\Testbench\package_path;
 
@@ -50,6 +52,14 @@ class TestCommand extends Command
 
         if (! is_testbench_cli()) {
             $this->setHidden(true);
+        }
+
+        if (package_version_compare('nunomaduro/collision', '8.9.4', '>=')) {
+            $this->addOption(
+                name: 'without-cache',
+                mode: InputOption::VALUE_NONE,
+                description: 'Indicates if cache configuration should be performed',
+            );
         }
     }
 

--- a/src/Foundation/Console/TestFallbackCommand.php
+++ b/src/Foundation/Console/TestFallbackCommand.php
@@ -32,6 +32,7 @@ class TestFallbackCommand extends Command
         {--profile : Lists top 10 slowest tests}
         {--recreate-databases : Indicates if the test databases should be re-created}
         {--drop-databases : Indicates if the test databases should be dropped}
+        {--without-cache : Indicates if cache configuration should be performed}
         {--without-databases : Indicates if database configuration should be performed}
         {--c|--custom-argument : Add custom env variables}
     ';


### PR DESCRIPTION
fixes #404