### PR TITLE
[7.x] Fixed `config/database.php` for PHP 8.5 compatibility

### DIFF
--- a/bin/configure-skeleton.php
+++ b/bin/configure-skeleton.php
@@ -101,6 +101,10 @@ transform([
 ], fn ($changes) => $files->replaceInFile(array_keys($changes), array_values($changes), "{$workingPath}/laravel/config/auth.php"));
 
 transform([
+    line("PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),", 4) => line("(PHP_VERSION_ID >= 80500 ? Pdo\Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),", 4),
+], fn ($changes) => $files->replaceInFile(array_keys($changes), array_values($changes), "{$workingPath}/laravel/config/database.php"));
+
+transform([
     line("'connection' => null,", 3) => line("'connection' => env('DB_CACHE_CONNECTION'),", 3),
     line("'table' => 'cache',", 3) => line("'table' => env('DB_CACHE_TABLE', 'cache'),", 3),
     line("'lock_connection' => null,", 3) => line("'lock_connection' => env('DB_CACHE_LOCK_CONNECTION'),", 3),

--- a/laravel/config/database.php
+++ b/laravel/config/database.php
@@ -59,7 +59,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                (PHP_VERSION_ID >= 80500 ? Pdo\Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 


### PR DESCRIPTION
Backports the `config/database.php` portion of #370 (11652485ae) to the 7.x branch.

On PHP 8.5, `PDO::MYSQL_ATTR_SSL_CA` emits a deprecation notice (`use Pdo\Mysql::ATTR_SSL_CA instead`), which shows up in the test output of every package that runs its suite on 8.5 with Testbench 7. Same fix as 10.x: guard on `PHP_VERSION_ID >= 80500` so the legacy constant is still used (and never evaluated as deprecated) on older runtimes. The matching `bin/configure-skeleton.php` transform is included so the skeleton change survives regeneration.

Verified the guarded expression on PHP 8.3, 8.4 and 8.5:

```
8.3: array(1009 => '/ca.pem')   // PDO::MYSQL_ATTR_SSL_CA, no notice
8.4: array(1009 => '/ca.pem')   // PDO::MYSQL_ATTR_SSL_CA, no notice
8.5: array(1008 => '/ca.pem')   // Pdo\Mysql::ATTR_SSL_CA, no notice
```

Also verified end-to-end by dropping the patched skeleton into a dependent package's vendor dir (winter/storm, 701 tests) and re-running its suite on PHP 8.5.5: the `PDO::MYSQL_ATTR_SSL_CA` deprecation notices disappear and the suite still passes.